### PR TITLE
61 endpoint student skills updaten

### DIFF
--- a/projojo_backend/db/schema.tql
+++ b/projojo_backend/db/schema.tql
@@ -87,7 +87,7 @@ relation requiresSkill,
 relation hasSkill,
     relates student @card(1),
     relates skill @card(1),
-    owns description @card(1);
+    owns description @card(0..1);
 
 relation registersForTask,
     relates student @card(1),

--- a/projojo_backend/db/schema.tql
+++ b/projojo_backend/db/schema.tql
@@ -62,13 +62,6 @@ relation authenticates,
     owns username @card(1),
     owns id @key;
 
-#relation accessPermission,
-#    relates supervisorRole as supervisor,
-#    relates projectRole as project;
-
-    #Project Creations
-    # Ik ben van mening dat we de createdAt hier willen hebben, een supervisor maakt een project(relatie -> projectCreation) aan en de timestamp laat zien waneer dit gebeurt.
-    # mischien kunnen we met een rule dit laten overerven naar het projectzelf, als we dat willen?
 relation creates,
     relates supervisor @card(1),
     relates project @card(0..),

--- a/projojo_backend/domain/models/skill.py
+++ b/projojo_backend/domain/models/skill.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Annotated, Optional
+from typing import Annotated
 from datetime import datetime
 
 class Skill(BaseModel):
@@ -10,7 +10,6 @@ class Skill(BaseModel):
         examples=["2025-04-21T10:02:58"]
     )]
 
-    
     class Config:
         from_attributes = True
         json_encoders = {
@@ -19,7 +18,7 @@ class Skill(BaseModel):
 
 
 class StudentSkill(Skill):
-    description: Optional[str] = None
-    
+    description: str | None = None
+
     class Config:
         from_attributes = True

--- a/projojo_backend/domain/repositories/skill_repository.py
+++ b/projojo_backend/domain/repositories/skill_repository.py
@@ -12,7 +12,7 @@ from ..models.skill import StudentSkill
 class SkillRepository(BaseRepository[Skill]):
     def __init__(self):
         super().__init__(Skill, "skill")
-    
+
     def get_by_id(self, id: str) -> Skill | None:
         escaped_id = id.replace('"', '\\"')
         query = f"""
@@ -32,7 +32,7 @@ class SkillRepository(BaseRepository[Skill]):
         if not results:
             raise ItemRetrievalException(Skill, f"Skill with ID {id} not found.")
         return self._map_to_model(results[0])
-    
+
     def get_all(self) -> list[Skill]:
         query = """
             match 
@@ -106,9 +106,11 @@ class SkillRepository(BaseRepository[Skill]):
         else:
             is_pending = str(is_pending_value).lower() == "true"
         created_at_str = result.get("createdAt", "")
-        
+
         # Convert createdAt string to datetime
-        created_at = datetime.fromisoformat(created_at_str) if created_at_str else datetime.now()
+        created_at = (
+            datetime.fromisoformat(created_at_str) if created_at_str else datetime.now()
+        )
 
         description = result.get("description")
         if description:
@@ -117,14 +119,14 @@ class SkillRepository(BaseRepository[Skill]):
                 name=name,
                 description=description,
                 is_pending=is_pending,
-                created_at=created_at
+                created_at=created_at,
             )
-        
+
         return Skill(
             id=name,  # Using name as the ID since it's marked as @key
             name=name,
             is_pending=is_pending,
-            created_at=created_at
+            created_at=created_at,
         )
 
     def get_task_skills(self, task_id: str) -> list[Skill]:
@@ -145,14 +147,12 @@ class SkillRepository(BaseRepository[Skill]):
             skill_name = result.get("skill_name", "")
             is_pending_value = result.get("isPending", True)
 
-            skills.append(Skill(
-                id=skill_name,  # Using name as the ID since it's marked as @key
-                name=skill_name,
-                is_pending=is_pending_value,
-                created_at=datetime.now()  # Assuming created_at is not needed here
-            ))
+            skills.append(
+                Skill(
+                    id=skill_name,  # Using name as the ID since it's marked as @key
+                    name=skill_name,
+                    is_pending=is_pending_value,
+                    created_at=datetime.now(),  # Assuming created_at is not needed here
+                )
+            )
         return skills
-    
-
-
-

--- a/projojo_backend/domain/repositories/skill_repository.py
+++ b/projojo_backend/domain/repositories/skill_repository.py
@@ -35,10 +35,10 @@ class SkillRepository(BaseRepository[Skill]):
 
     def get_all(self) -> list[Skill]:
         query = """
-            match 
+            match
                 $skill isa skill;
-            fetch { 
-                'name': $skill.name,	
+            fetch {
+                'name': $skill.name,
                 'isPending': $skill.isPending,
                 'createdAt': $skill.createdAt,
             };
@@ -51,7 +51,7 @@ class SkillRepository(BaseRepository[Skill]):
         escaped_student_id = student_id.replace('"', '\\"')
         query = f"""
             match
-                $student isa student, 
+                $student isa student,
                 has email "{escaped_student_id}";
                 $hasSkill isa hasSkill( $student, $skill),
                 has description $description;
@@ -98,6 +98,21 @@ class SkillRepository(BaseRepository[Skill]):
                     $hasSkill;
             """
             Db.write_transact(query)
+
+    def update_student_skill_description(self, student_id: str, skill_id: str, description: str):
+        escaped_student_id = student_id.replace('"', '\\"')
+        escaped_skill_id = skill_id.replace('"', '\\"')
+        escaped_description = description.replace('"', '\\"')
+
+        query = f"""
+            match
+                $student isa student, has email "{escaped_student_id}";
+                $skill isa skill, has name "{escaped_skill_id}";
+                $hasSkill isa hasSkill (student: $student, skill: $skill);
+            update
+                $hasSkill has description "{escaped_description}";
+        """
+        Db.write_transact(query)
 
     def create(self, skill: Skill) -> Skill:
         # Generate a creation timestamp if not provided

--- a/projojo_backend/routes/student_router.py
+++ b/projojo_backend/routes/student_router.py
@@ -25,9 +25,10 @@ async def get_student_skills(email: str = Path(..., description="Student email")
     Get all skills for a student
     """
     student = user_repo.get_student_by_id(email)
-    skills = skill_repo.get_student_skills(student.email)
 
-    return StudentSkills(**student.model_dump(), Skills=skills)
+    if not student:
+        raise HTTPException(status_code=404, detail="Student not found")
+    return student
 
 
 @router.put("/{email}/skills")

--- a/projojo_backend/routes/student_router.py
+++ b/projojo_backend/routes/student_router.py
@@ -1,11 +1,12 @@
-from fastapi import APIRouter, Path, Body, HTTPException
+from fastapi import APIRouter, Path, Body, HTTPException, Depends
+from auth.jwt_utils import get_token_payload
 
 from domain.repositories import SkillRepository, UserRepository
+from domain.models.skill import StudentSkill
 
 skill_repo = SkillRepository()
 user_repo = UserRepository()
 
-from domain.models import StudentSkills
 
 router = APIRouter(prefix="/students", tags=["Student Endpoints"])
 
@@ -42,8 +43,39 @@ async def update_student_skills(
     try:
         skill_repo.update_student_skills(email, skills)
         return {"message": "Skills succesvol bijgewerkt"}
-    except Exception as e:
+    except Exception:
         raise HTTPException(
             status_code=500,
-            detail=f"Er is iets misgegaan bij het bijwerken van de skills: {str(e)}",
+            detail="Er is iets misgegaan bij het bijwerken van de skills",
+        )
+
+
+@router.patch("/{student_id}/skills/{skill_id}")
+async def update_student_skill_description(
+    student_id: str = Path(..., description="Student ID"),
+    skill_id: str = Path(..., description="Skill ID"),
+    skill: StudentSkill = Body(..., description="Skill object with updated description"),
+    payload: dict = Depends(get_token_payload)
+):
+    """
+    Update a specific skill's description for a student
+    """
+    if payload.get("role") != "student" or payload.get("sub") != student_id:
+        raise HTTPException(status_code=403, detail="Studenten kunnen alleen hun eigen skills bijwerken")
+
+    user = user_repo.get_student_by_id(student_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="Student bestaat niet")
+
+    skill_ids = [skill.get("id") for skill in user.get("Skills")]
+    if skill_id not in skill_ids:
+        raise HTTPException(status_code=404, detail="De skill die je probeert te updaten staat niet in jouw profiel")
+
+    try:
+        skill_repo.update_student_skill_description(student_id, skill_id, skill.description)
+        return {"message": "Skill description successfully updated"}
+    except Exception:
+        raise HTTPException(
+            status_code=500,
+            detail="Er is iets misgegaan bij het opslaan van de beschrijving",
         )

--- a/projojo_backend/routes/student_router.py
+++ b/projojo_backend/routes/student_router.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Path, Body, HTTPException
 
 from domain.repositories import SkillRepository, UserRepository
+
 skill_repo = SkillRepository()
 user_repo = UserRepository()
 
 from domain.models import StudentSkills
 
 router = APIRouter(prefix="/students", tags=["Student Endpoints"])
+
 
 @router.get("/")
 async def get_all_students():
@@ -25,7 +27,22 @@ async def get_student_skills(email: str = Path(..., description="Student email")
     student = user_repo.get_student_by_id(email)
     skills = skill_repo.get_student_skills(student.email)
 
-    return StudentSkills(
-        **student.model_dump(),
-        Skills=skills
-    )
+    return StudentSkills(**student.model_dump(), Skills=skills)
+
+
+@router.put("/{email}/skills")
+async def update_student_skills(
+    email: str = Path(..., description="Student email"),
+    skills: list[str] = Body(..., description="List of skillnames"),
+):
+    """
+    Update skills for a student
+    """
+    try:
+        skill_repo.update_student_skills(email, skills)
+        return {"message": "Skills succesvol bijgewerkt"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Er is iets misgegaan bij het bijwerken van de skills: {str(e)}",
+        )

--- a/projojo_frontend/src/components/SkillsEditor.jsx
+++ b/projojo_frontend/src/components/SkillsEditor.jsx
@@ -42,8 +42,8 @@ export default function SkillsEditor({ children, allSkills, initialSkills, isEdi
 
     const toggleSkill = (skill) => {
         setSelectedSkills(currentSelectedSkills => {
-            if (currentSelectedSkills.map(s => (s.skillId || s.id) === (skill.skillId || skill.id))) {
-                return currentSelectedSkills.filter(s => (s.skillId || s.id) !== (skill.skillId || skill.id))
+            if (currentSelectedSkills.some(s => s.name === skill.name)) {
+                return currentSelectedSkills.filter(s => s.name !== skill.name);
             } else {
                 return [...currentSelectedSkills, skill]
             }
@@ -117,7 +117,7 @@ export default function SkillsEditor({ children, allSkills, initialSkills, isEdi
             <div className="flex flex-wrap gap-2 items-center">
                 {selectedSkills.length === 0 && <span>Er zijn geen skills geselecteerd.</span>}
                 {selectedSkills.map((skill) => (
-                    <SkillBadge key={skill.skillId || skill.id} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`Verwijder ${skill.name}`}>
+                    <SkillBadge key={skill.name} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`Verwijder ${skill.name}`}>
                         <span className="ps-1 font-bold text-xl leading-3">×</span>
                     </SkillBadge>
                 ))}
@@ -163,7 +163,7 @@ export default function SkillsEditor({ children, allSkills, initialSkills, isEdi
                     )}
                     <div className="flex flex-wrap gap-2 items-center">
                         {filteredSkills.slice(0, maxSkillsDisplayed).map((skill) => (
-                            <SkillBadge key={skill.skillId || skill.id} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`${skill.name} toevoegen`}>
+                            <SkillBadge key={skill.name} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`${skill.name} toevoegen`}>
                                 <span className="ps-1 font-bold text-xl leading-3">+</span>
                             </SkillBadge>
                         ))}
@@ -173,7 +173,7 @@ export default function SkillsEditor({ children, allSkills, initialSkills, isEdi
                         {filteredSkills.length > maxSkillsDisplayed && showAllSkills && (
                             <>
                                 {filteredSkills.slice(maxSkillsDisplayed).map((skill) => (
-                                    <SkillBadge key={skill.skillId || skill.id} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`${skill.name} toevoegen`}>
+                                    <SkillBadge key={skill.name} skillName={skill.name} isPending={skill.isPending} onClick={() => toggleSkill(skill)} ariaLabel={`${skill.name} toevoegen`}>
                                         <span className="ps-1 font-bold text-xl leading-3">+</span>
                                     </SkillBadge>
                                 ))}

--- a/projojo_frontend/src/components/SkillsEditor.jsx
+++ b/projojo_frontend/src/components/SkillsEditor.jsx
@@ -90,8 +90,7 @@ export default function SkillsEditor({ children, allSkills, initialSkills, isEdi
                     if (ignore) return
                     // Handle the new API response format
                     if (data.skill_ids) {
-                        // If we have skill_ids directly in the user object
-                        setStudentsSkills(data.skill_ids)
+                        setStudentsSkills(data.skill_ids.map(skill => skill.skill_name))
                     } else if (data.skills) {
                         // If we have a skills array
                         setStudentsSkills(data.skills.map(skill => skill.id))

--- a/projojo_frontend/src/components/StudentProfileSkill.jsx
+++ b/projojo_frontend/src/components/StudentProfileSkill.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { getSkillsFromStudent } from "../services";
+import { updateStudentSkillDescription } from "../services";
 import Alert from "./Alert";
 import { useAuth } from "./AuthProvider";
 
@@ -14,23 +14,18 @@ export default function StudentProfileSkill({ skill, isOwnProfile }) {
         setError("");
 
         const dataFormat = {
-            skills: {
-                id: skill.id,
-                name: skill.name,
-                is_pending: skill.is_pending,
-                description: description
-            }
+            ...skill,
+            description: description
         };
 
-        try {
-            const response = await getSkillsFromStudent(authData.userId);
-
-            // For now, we're just updating the local state since the update endpoint is commented out
-            skill.description = description;
-            setIsEditing(false);
-        } catch (error) {
-            setError("Er is iets misgegaan bij het opslaan van de beschrijving.");
-        }
+        updateStudentSkillDescription(authData.userId, dataFormat)
+            .then(() => {
+                skill.description = description;
+                setIsEditing(false);
+            })
+            .catch((error) => {
+                setError(error.message);
+            });
     };
 
     const handleClose = () => {

--- a/projojo_frontend/src/components/StudentProfileSkills.jsx
+++ b/projojo_frontend/src/components/StudentProfileSkills.jsx
@@ -48,7 +48,7 @@ export default function StudentProfileSkills({ student, setFetchAmount }) {
     // Map student skills to the format expected by SkillsEditor
     const currentSkills = student?.Skills?.map((skill) => {
         return {
-            skillId: skill.name,
+            skillId: skill.id,
             name: skill.name,
             isPending: skill.is_pending,
             description: skill.description,
@@ -75,7 +75,7 @@ export default function StudentProfileSkills({ student, setFetchAmount }) {
                         setError={setStudentSkillsError}
                         isAbsolute={false}
                     >
-                        {student?.Skills?.map(skill => <StudentProfileSkill key={skill.name} skill={skill} isOwnProfile={isOwnProfile} />)}
+                        {student?.Skills?.map(skill => <StudentProfileSkill key={skill.id} skill={skill} isOwnProfile={isOwnProfile} />)}
                     </SkillsEditor>
                 </div>
             </div>

--- a/projojo_frontend/src/components/StudentProfileSkills.jsx
+++ b/projojo_frontend/src/components/StudentProfileSkills.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getSkills, /*updateStudentSkills*/ } from "../services";
+import { getSkills, updateStudentSkills } from "../services";
 import Alert from "./Alert";
 import { useAuth } from "./AuthProvider";
 import SkillsEditor from "./SkillsEditor";
@@ -15,12 +15,12 @@ export default function StudentProfileSkills({ student, setFetchAmount }) {
     const isOwnProfile = authData.type === "student" && authData.userId === student.id;
 
     const handleSave = async (skills) => {
-        const skillIds = skills.map((skill) => skill.skillId);
+        const skillNames = skills.map((skill) => skill.name);
 
         setStudentSkillsError("");
 
         try {
-            //await updateStudentSkills(skillIds);
+            await updateStudentSkills(student.email, skillNames);
             setIsEditing(false)
             setFetchAmount((currentAmount) => currentAmount + 1);
         } catch (error) {
@@ -48,7 +48,7 @@ export default function StudentProfileSkills({ student, setFetchAmount }) {
     // Map student skills to the format expected by SkillsEditor
     const currentSkills = student?.Skills?.map((skill) => {
         return {
-            skillId: skill.id,
+            skillId: skill.name,
             name: skill.name,
             isPending: skill.is_pending,
             description: skill.description,
@@ -75,7 +75,7 @@ export default function StudentProfileSkills({ student, setFetchAmount }) {
                         setError={setStudentSkillsError}
                         isAbsolute={false}
                     >
-                        {student?.Skills?.map(skill => <StudentProfileSkill key={skill.id} skill={skill} isOwnProfile={isOwnProfile} />)}
+                        {student?.Skills?.map(skill => <StudentProfileSkill key={skill.name} skill={skill} isOwnProfile={isOwnProfile} />)}
                     </SkillsEditor>
                 </div>
             </div>

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -184,7 +184,7 @@ export function getTasks(projectName) {
 /**
  *
  * @param {string} email
- * @returns {Promise<{id: string, email: string, full_name: string, image_path: string, password_hash: string, type: string, school_account_name: string, skill_ids: string[], registered_task_ids: string[]}>}
+ * @returns {Promise<{id: string, email: string, full_name: string, image_path: string, password_hash: string, type: string, school_account_name: string, skill_ids: {skill_name: string}[], registered_task_ids: {task_name: string}[], Skills: {id: string, name: string, is_pending: boolean, created_at: string, description: string}[]}>}
  */
 export function getUser(email) {
     return fetchWithError(`${API_BASE_URL}users/${email}`);
@@ -213,7 +213,7 @@ export function getSkillsFromStudent(email) {
  * @param {string} email
  * @param {string[]} skills
  */
-export function updateStudentSkills(email, skills) {   
+export function updateStudentSkills(email, skills) {
     return fetchWithError(`${API_BASE_URL}students/${email}/skills`, {
         method: "PUT",
         body: JSON.stringify(skills),
@@ -324,7 +324,7 @@ export function getTaskSkills(taskName) {
  *
  * @param {string} newBusinessName
  */
-export function createNewBusiness(newBusinessName) {   
+export function createNewBusiness(newBusinessName) {
     return fetchWithError(`${API_BASE_URL}businesses/`, {
         method: "POST",
         body: JSON.stringify(newBusinessName),

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -220,6 +220,13 @@ export function updateStudentSkills(email, skills) {
     });
 }
 
+export function updateStudentSkillDescription(email, skill) {
+    return fetchWithError(`${API_BASE_URL}students/${email}/skills/${skill.id}`, {
+        method: "PATCH",
+        body: JSON.stringify(skill),
+    });
+}
+
 export function getRegistrations() {
     return fetchWithError(`${API_BASE_URL}registrations`);
 }

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -228,10 +228,6 @@ export function updateStudentSkillDescription(email, skill) {
     });
 }
 
-export function getRegistrations() {
-    return fetchWithError(`${API_BASE_URL}registrations`);
-}
-
 /**
  * @param {string} taskId
  * @returns {Promise<{student: {id: string, full_name: string, skills: {id: string, name: string, is_pending: boolean, created_at: string, description: string}[]}, reason: string}[]>}

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -209,6 +209,17 @@ export function getSkillsFromStudent(email) {
     return fetchWithError(`${API_BASE_URL}students/${email}/skills`);
 }
 
+/**
+ * @param {string} email
+ * @param {string[]} skills
+ */
+export function updateStudentSkills(email, skills) {   
+    return fetchWithError(`${API_BASE_URL}students/${email}/skills`, {
+        method: "PUT",
+        body: JSON.stringify(skills),
+    });
+}
+
 export function getRegistrations() {
     return fetchWithError(`${API_BASE_URL}registrations`);
 }


### PR DESCRIPTION
~Dit lijkt allemaal te werken op 1 bug na: als je alle skills van een student verwijderd, wordt deze student niet meer opgehaald via de get_student_by_id methode in de user_repository omdat hij alleen de student records ophaalt die hasSkill relaties hebben~

Lijst van skills updaten + individuele skill omschrijving aanpassen