### PR TITLE
feat: Task-level status consensus mechanism (Lopend/Afgerond/Afgebroken)

### DIFF
--- a/projojo_backend/db/schema.tql
+++ b/projojo_backend/db/schema.tql
@@ -5,7 +5,9 @@ entity user @abstract,
     owns email @card(1),
     owns fullName @card(1),
     owns imagePath @card(1),
-    plays oauthAuthentication:user @card(1..10);
+    plays oauthAuthentication:user @card(1..10),
+    plays statusChangeRequest:requester @card(0..),
+    plays statusChangeRequest:responder @card(0..);
 
 entity supervisor sub user,
     plays manages:supervisor @card(1),
@@ -136,7 +138,9 @@ relation registersForTask,
     owns requestedAt @card(0..1),
     owns acceptedAt @card(0..1),
     owns startedAt @card(0..1),
-    owns completedAt @card(0..1);
+    owns completedAt @card(0..1),
+    owns registrationStatus @card(0..1),
+    plays statusChangeRequest:registration @card(0..);
 
 relation businessInvite,
     relates business @card(1),
@@ -158,6 +162,20 @@ relation hasPortfolio,
 relation hasTheme,
     relates project @card(1),
     relates theme @card(1);
+
+# Status change consensus - per taak-registratie
+relation statusChangeRequest,
+    relates registration @card(1),      # de registersForTask die beoordeeld wordt
+    relates requester @card(0..1),      # user die initieert (leeg bij auto end_review)
+    relates responder @card(0..1),      # user die reageert
+    owns id @key,
+    owns requestType @card(1),          # "completion" / "cancellation" / "end_review"
+    owns reason @card(1),
+    owns requestStatus @card(1),        # "pending" / "approved" / "denied" / "auto_approved"
+    owns createdAt @card(1),
+    owns respondedAt @card(0..1),
+    owns responseMessage @card(0..1),
+    owns autoApproveAt @card(0..1);     # Taak endDate + 14 dagen (alleen bij end_review)
 
 #Werkt helaas nog niet :(
 # TLDR: maakt automatisch een permission relatie aan als een supervisor een project aanmaakt permissie voor wat? zien we dan wel maar wss aanpassingen doen etc
@@ -208,3 +226,10 @@ attribute icon value string;
 attribute themeDescription value string;
 attribute color value string;
 attribute displayOrder value integer;
+attribute reason value string;
+attribute requestType value string @values("completion", "cancellation", "end_review");
+attribute requestStatus value string @values("pending", "approved", "denied", "auto_approved");
+attribute responseMessage value string;
+attribute autoApproveAt value datetime-tz;
+attribute respondedAt value datetime-tz;
+attribute registrationStatus value string @values("lopend", "afgerond", "afgebroken");

--- a/projojo_backend/db/seed.tql
+++ b/projojo_backend/db/seed.tql
@@ -1468,7 +1468,7 @@ insert
     # Emma's COMPLETED projects for portfolio/Gantt (10 total)
     # ============================================
     
-    # 1. IoT Sensor Specialist @ De Gouden Akker (Jul-Oct 2025)
+    # 1. IoT Sensor Specialist @ De Gouden Akker (Jul-Oct 2025) - AFGEROND via consensus
     $tr1 isa registersForTask (student: $u2, task: $t1),
         has description "Ik heb ervaring met IoT sensoren en wil graag bijdragen aan duurzame landbouw",
         has isAccepted true,
@@ -1477,9 +1477,10 @@ insert
         has requestedAt 2025-07-01T09:00:00+0000,
         has acceptedAt 2025-07-05T14:30:00+0000,
         has startedAt 2025-07-10T09:00:00+0000,
-        has completedAt 2025-10-15T16:00:00+0000;
+        has completedAt 2025-10-15T16:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 2. Data Analytics Developer @ De Gouden Akker (Aug-Nov 2025)
+    # 2. Data Analytics Developer @ De Gouden Akker (Aug-Nov 2025) - AFGEROND via consensus
     $tr2 isa registersForTask (student: $u2, task: $t2),
         has description "Mijn data analytics ervaring kan goed van pas komen bij dit dashboard project",
         has isAccepted true,
@@ -1488,9 +1489,10 @@ insert
         has requestedAt 2025-08-01T09:30:00+0000,
         has acceptedAt 2025-08-03T11:00:00+0000,
         has startedAt 2025-08-08T09:00:00+0000,
-        has completedAt 2025-11-20T15:30:00+0000;
+        has completedAt 2025-11-20T15:30:00+0000,
+        has registrationStatus "afgerond";
 
-    # 3. Soil Health Data Analyst @ De Gouden Akker (Sep-Dec 2025)
+    # 3. Soil Health Data Analyst @ De Gouden Akker (Sep-Dec 2025) - AFGEROND
     $tr_emma3 isa registersForTask (student: $u2, task: $t36),
         has description "Bodemgezondheid analyse past bij mijn interesse in duurzame landbouw",
         has isAccepted true,
@@ -1499,9 +1501,10 @@ insert
         has requestedAt 2025-09-01T10:00:00+0000,
         has acceptedAt 2025-09-04T09:30:00+0000,
         has startedAt 2025-09-10T09:00:00+0000,
-        has completedAt 2025-12-01T14:00:00+0000;
+        has completedAt 2025-12-01T14:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 4. Machine Learning Engineer @ Veeteelt Groep (Oct-Dec 2025)
+    # 4. Machine Learning Engineer @ Veeteelt Groep (Oct-Dec 2025) - AFGEROND
     $tr_emma4 isa registersForTask (student: $u2, task: $t6),
         has description "ML voor melkproductie optimalisatie is een interessante uitdaging",
         has isAccepted true,
@@ -1510,9 +1513,10 @@ insert
         has requestedAt 2025-10-01T08:00:00+0000,
         has acceptedAt 2025-10-03T16:00:00+0000,
         has startedAt 2025-10-07T09:00:00+0000,
-        has completedAt 2025-12-20T17:00:00+0000;
+        has completedAt 2025-12-20T17:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 5. Farm Dashboard Developer @ SmartFarm Solutions (Aug-Sep 2025)
+    # 5. Farm Dashboard Developer @ SmartFarm Solutions (Aug-Sep 2025) - AFGEBROKEN (vroegtijdig gestopt)
     $tr_emma5 isa registersForTask (student: $u2, task: $t12),
         has description "Dashboard ontwikkeling is mijn specialiteit",
         has isAccepted true,
@@ -1521,9 +1525,10 @@ insert
         has requestedAt 2025-08-15T11:00:00+0000,
         has acceptedAt 2025-08-17T10:00:00+0000,
         has startedAt 2025-08-20T09:00:00+0000,
-        has completedAt 2025-09-30T16:30:00+0000;
+        has completedAt 2025-09-30T16:30:00+0000,
+        has registrationStatus "afgebroken";
 
-    # 6. Climate AI Specialist @ Groene Kassen (Nov 2025-Jan 2026)
+    # 6. Climate AI Specialist @ Groene Kassen (Nov 2025-Jan 2026) - AFGEROND
     $tr_emma6 isa registersForTask (student: $u2, task: $t15),
         has description "AI voor klimaatbeheersing combineert mijn passie voor duurzaamheid met tech",
         has isAccepted true,
@@ -1532,9 +1537,10 @@ insert
         has requestedAt 2025-11-01T09:00:00+0000,
         has acceptedAt 2025-11-04T14:00:00+0000,
         has startedAt 2025-11-08T09:00:00+0000,
-        has completedAt 2026-01-10T15:00:00+0000;
+        has completedAt 2026-01-10T15:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 7. Irrigation System Engineer @ SmartFarm Solutions (Sep-Oct 2025)
+    # 7. Irrigation System Engineer @ SmartFarm Solutions (Sep-Oct 2025) - AFGEROND
     $tr_emma7 isa registersForTask (student: $u2, task: $t11),
         has description "IoT sensoren voor irrigatie is een praktische toepassing van mijn skills",
         has isAccepted true,
@@ -1543,9 +1549,10 @@ insert
         has requestedAt 2025-09-05T08:30:00+0000,
         has acceptedAt 2025-09-08T11:00:00+0000,
         has startedAt 2025-09-12T09:00:00+0000,
-        has completedAt 2025-10-25T16:00:00+0000;
+        has completedAt 2025-10-25T16:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 8. Lab Data Manager @ Bodemexperts (Oct-Nov 2025)
+    # 8. Lab Data Manager @ Bodemexperts (Oct-Nov 2025) - AFGEROND
     $tr_emma8 isa registersForTask (student: $u2, task: $t19),
         has description "Bodemanalyse digitaliseren past bij mijn achtergrond",
         has isAccepted true,
@@ -1554,9 +1561,10 @@ insert
         has requestedAt 2025-10-10T09:00:00+0000,
         has acceptedAt 2025-10-12T15:30:00+0000,
         has startedAt 2025-10-16T09:00:00+0000,
-        has completedAt 2025-11-28T14:00:00+0000;
+        has completedAt 2025-11-28T14:00:00+0000,
+        has registrationStatus "afgerond";
 
-    # 9. Water Quality Monitor @ AquaCultuur Innovatie (Nov-Dec 2025)
+    # 9. Water Quality Monitor @ AquaCultuur Innovatie (Nov-Dec 2025) - AFGEROND
     $tr_emma9 isa registersForTask (student: $u2, task: $t21),
         has description "Waterkwaliteit monitoring met IoT sensoren is interessant",
         has isAccepted true,
@@ -1565,9 +1573,10 @@ insert
         has requestedAt 2025-11-05T10:00:00+0000,
         has acceptedAt 2025-11-07T09:00:00+0000,
         has startedAt 2025-11-11T09:00:00+0000,
-        has completedAt 2025-12-15T16:30:00+0000;
+        has completedAt 2025-12-15T16:30:00+0000,
+        has registrationStatus "afgerond";
 
-    # 10. Harvest Prediction Analyst @ SmartFarm Solutions (Dec 2025-Jan 2026)
+    # 10. Harvest Prediction Analyst @ SmartFarm Solutions (Dec 2025-Jan 2026) - AFGEROND
     $tr_emma10 isa registersForTask (student: $u2, task: $t14),
         has description "Machine learning voor oogstvoorspellingen is een mooie uitdaging",
         has isAccepted true,
@@ -1576,7 +1585,8 @@ insert
         has requestedAt 2025-12-01T08:00:00+0000,
         has acceptedAt 2025-12-03T14:00:00+0000,
         has startedAt 2025-12-08T09:00:00+0000,
-        has completedAt 2026-01-05T17:00:00+0000;
+        has completedAt 2026-01-05T17:00:00+0000,
+        has registrationStatus "afgerond";
 
     # ============================================
     # Emma's ACTIVE tasks (started but not completed)
@@ -2039,3 +2049,34 @@ insert
     $pt_theme_arn4 isa hasTheme (project: $p_arn2, theme: $theme5);
     $pt_theme_arn5 isa hasTheme (project: $p_arn3, theme: $theme6);
     $pt_theme_arn6 isa hasTheme (project: $p_arn3, theme: $theme3);
+
+    # ============================================
+    # Status Change Requests (Consensus Systeem)
+    # ============================================
+
+    # Scenario 1: Emma wil haar actieve Computer Vision taak afronden (pending completion request)
+    # Supervisor van Fruitboomgaarden Van Dijk ($s8) moet nog reageren
+    $scr1 isa statusChangeRequest (
+        registration: $tr_emma_active1,
+        requester: $u2
+    ),
+        has id "scr-001-pending-completion",
+        has requestType "completion",
+        has reason "Ik heb het computer vision model afgerond en de documentatie is klaar. Graag als afgerond markeren.",
+        has requestStatus "pending",
+        has createdAt 2026-02-01T14:00:00+0000;
+
+    # Scenario 2: Afgerond verzoek dat is goedgekeurd (voor de afgebroken Farm Dashboard taak)
+    # Dit was het cancellation request dat is goedgekeurd
+    $scr2 isa statusChangeRequest (
+        registration: $tr_emma5,
+        requester: $u2,
+        responder: $s3
+    ),
+        has id "scr-002-approved-cancellation",
+        has requestType "cancellation",
+        has reason "Door veranderde projectvereisten kan ik het dashboard niet meer afronden zoals gepland.",
+        has requestStatus "approved",
+        has createdAt 2025-09-20T10:00:00+0000,
+        has respondedAt 2025-09-22T15:00:00+0000,
+        has responseMessage "Begrijpelijk, bedankt voor je eerlijkheid. We hebben het project aangepast.";

--- a/projojo_backend/domain/repositories/status_change_repository.py
+++ b/projojo_backend/domain/repositories/status_change_repository.py
@@ -1,0 +1,570 @@
+"""
+Repository for managing status change requests (consensus mechanism).
+
+Each registersForTask (student-task pair) can have a statusChangeRequest
+for completion, cancellation, or end-of-term review.
+"""
+from datetime import datetime, timedelta
+from db.initDatabase import Db
+from service.uuid_service import generate_uuid
+
+
+class StatusChangeRepository:
+    """Repository for status change request CRUD operations."""
+
+    # Auto-approve after 14 days
+    AUTO_APPROVE_DAYS = 14
+
+    def create_request(
+        self,
+        task_id: str,
+        student_id: str,
+        requester_id: str,
+        request_type: str,  # "completion" | "cancellation"
+        reason: str,
+    ) -> dict:
+        """
+        Create a manual status change request (student or supervisor initiates).
+        Returns the created request data.
+        """
+        request_id = generate_uuid()
+        now = datetime.now()
+
+        query = """
+            match
+                $task isa task, has id ~task_id;
+                $student isa student, has id ~student_id;
+                $registration isa registersForTask (student: $student, task: $task);
+                $requester isa user, has id ~requester_id;
+            insert
+                $scr isa statusChangeRequest (
+                    registration: $registration,
+                    requester: $requester
+                ),
+                has id ~request_id,
+                has requestType ~request_type,
+                has reason ~reason,
+                has requestStatus "pending",
+                has createdAt ~created_at;
+        """
+        Db.write_transact(query, {
+            "task_id": task_id,
+            "student_id": student_id,
+            "requester_id": requester_id,
+            "request_id": request_id,
+            "request_type": request_type,
+            "reason": reason,
+            "created_at": now,
+        })
+
+        return {
+            "id": request_id,
+            "request_type": request_type,
+            "reason": reason,
+            "request_status": "pending",
+            "created_at": now.isoformat(),
+        }
+
+    def create_end_review(self, task_id: str, student_id: str) -> dict:
+        """
+        Create an automatic end_review request when a task's endDate passes.
+        No requester (system-triggered). Sets autoApproveAt = now + 14 days.
+        """
+        request_id = generate_uuid()
+        now = datetime.now()
+        auto_approve_at = now + timedelta(days=self.AUTO_APPROVE_DAYS)
+
+        query = """
+            match
+                $task isa task, has id ~task_id;
+                $student isa student, has id ~student_id;
+                $registration isa registersForTask (student: $student, task: $task);
+            insert
+                $scr isa statusChangeRequest (
+                    registration: $registration
+                ),
+                has id ~request_id,
+                has requestType "end_review",
+                has reason "Taakperiode is verstreken. Beoordeel of de taak is afgerond of afgebroken.",
+                has requestStatus "pending",
+                has createdAt ~created_at,
+                has autoApproveAt ~auto_approve_at;
+        """
+        Db.write_transact(query, {
+            "task_id": task_id,
+            "student_id": student_id,
+            "request_id": request_id,
+            "created_at": now,
+            "auto_approve_at": auto_approve_at,
+        })
+
+        return {
+            "id": request_id,
+            "request_type": "end_review",
+            "request_status": "pending",
+            "auto_approve_at": auto_approve_at.isoformat(),
+        }
+
+    def get_pending_request(self, task_id: str, student_id: str) -> dict | None:
+        """
+        Get the current pending status change request for a registration.
+        Returns None if no pending request exists.
+        """
+        query = """
+            match
+                $task isa task, has id ~task_id;
+                $student isa student, has id ~student_id;
+                $registration isa registersForTask (student: $student, task: $task);
+                $scr isa statusChangeRequest (registration: $registration),
+                    has id $scr_id,
+                    has requestType $req_type,
+                    has reason $reason,
+                    has requestStatus "pending",
+                    has createdAt $created_at;
+            fetch {
+                'id': $scr_id,
+                'request_type': $req_type,
+                'reason': $reason,
+                'created_at': $created_at,
+                'auto_approve_at': [$scr.autoApproveAt],
+                'requester': [
+                    match
+                        $scr_inner isa statusChangeRequest (
+                            registration: $registration,
+                            requester: $req_user
+                        ), has id $scr_id;
+                        $req_user has id $req_user_id,
+                            has fullName $req_user_name;
+                    fetch {
+                        'id': $req_user_id,
+                        'full_name': $req_user_name
+                    };
+                ]
+            };
+        """
+        results = Db.read_transact(query, {
+            "task_id": task_id,
+            "student_id": student_id,
+        })
+
+        if not results:
+            return None
+
+        r = results[0]
+        auto_approve = r.get("auto_approve_at", [])
+        requester_list = r.get("requester", [])
+        requester = requester_list[0] if requester_list else None
+
+        return {
+            "id": r.get("id"),
+            "request_type": r.get("request_type"),
+            "reason": r.get("reason"),
+            "request_status": "pending",
+            "created_at": r.get("created_at"),
+            "auto_approve_at": auto_approve[0] if auto_approve else None,
+            "requester": requester,
+        }
+
+    def respond_to_request(
+        self,
+        request_id: str,
+        responder_id: str,
+        approved: bool,
+        response_message: str = "",
+    ) -> dict:
+        """
+        Respond to a pending status change request (approve or deny).
+        If approved:
+          - completion/end_review -> set registrationStatus = "afgerond"
+          - cancellation -> set registrationStatus = "afgebroken"
+        If denied: request is closed, no status change.
+        """
+        now = datetime.now()
+        new_status = "approved" if approved else "denied"
+
+        # First update the request status and add responder
+        update_query = """
+            match
+                $scr isa statusChangeRequest, has id ~request_id, has requestStatus "pending";
+                $responder isa user, has id ~responder_id;
+            update
+                $scr has requestStatus ~new_status;
+                $scr has respondedAt ~responded_at;
+                $scr has responseMessage ~response_message;
+        """
+        Db.write_transact(update_query, {
+            "request_id": request_id,
+            "responder_id": responder_id,
+            "new_status": new_status,
+            "responded_at": now,
+            "response_message": response_message,
+        })
+
+        # Add responder role to the relation
+        try:
+            responder_query = """
+                match
+                    $scr isa statusChangeRequest, has id ~request_id;
+                    $responder isa user, has id ~responder_id;
+                insert
+                    $scr (responder: $responder);
+            """
+            Db.write_transact(responder_query, {
+                "request_id": request_id,
+                "responder_id": responder_id,
+            })
+        except Exception:
+            pass  # Non-critical if adding responder role fails
+
+        # If approved, update the registration status
+        if approved:
+            # Determine the new registration status based on request type
+            type_query = """
+                match
+                    $scr isa statusChangeRequest, has id ~request_id,
+                        has requestType $req_type;
+                fetch {
+                    'request_type': $req_type
+                };
+            """
+            type_results = Db.read_transact(type_query, {"request_id": request_id})
+            if type_results:
+                request_type = type_results[0].get("request_type")
+                if request_type == "cancellation":
+                    reg_status = "afgebroken"
+                else:
+                    reg_status = "afgerond"
+
+                # Update the registration status
+                status_query = """
+                    match
+                        $scr isa statusChangeRequest (registration: $registration),
+                            has id ~request_id;
+                    update
+                        $registration has registrationStatus ~reg_status;
+                """
+                Db.write_transact(status_query, {
+                    "request_id": request_id,
+                    "reg_status": reg_status,
+                })
+
+        return {
+            "id": request_id,
+            "request_status": new_status,
+            "responded_at": now.isoformat(),
+        }
+
+    def get_pending_requests_for_user(self, user_id: str) -> list[dict]:
+        """
+        Get all pending status change requests where this user needs to respond.
+        
+        Logic:
+        - If requester is a student -> the supervisor of the project's business must respond
+        - If requester is a supervisor -> the student must respond
+        - For end_review (no requester) -> both student and supervisor can respond
+        
+        This returns ALL pending requests related to this user's registrations or tasks.
+        """
+        # Pending requests for a student (requests where they are the registration student)
+        student_query = """
+            match
+                $user isa student, has id ~user_id;
+                $registration isa registersForTask (student: $user, task: $task);
+                $scr isa statusChangeRequest (registration: $registration),
+                    has id $scr_id,
+                    has requestType $req_type,
+                    has reason $reason,
+                    has requestStatus "pending",
+                    has createdAt $created_at;
+                $task has id $task_id, has name $task_name;
+                $ct isa containsTask (project: $project, task: $task);
+                $project has id $project_id, has name $project_name;
+            fetch {
+                'id': $scr_id,
+                'request_type': $req_type,
+                'reason': $reason,
+                'created_at': $created_at,
+                'auto_approve_at': [$scr.autoApproveAt],
+                'task_id': $task_id,
+                'task_name': $task_name,
+                'project_id': $project_id,
+                'project_name': $project_name,
+                'requester': [
+                    match
+                        $scr_inner isa statusChangeRequest (
+                            registration: $registration,
+                            requester: $req_user
+                        ), has id $scr_id;
+                        $req_user has id $req_uid, has fullName $req_uname;
+                    fetch {
+                        'id': $req_uid,
+                        'full_name': $req_uname
+                    };
+                ]
+            };
+        """
+
+        # Pending requests for a supervisor (requests on tasks in their business projects)
+        supervisor_query = """
+            match
+                $user isa supervisor, has id ~user_id;
+                $manages isa manages (supervisor: $user, business: $business);
+                $hasProjects isa hasProjects (business: $business, project: $project);
+                $project has id $project_id, has name $project_name;
+                $ct isa containsTask (project: $project, task: $task);
+                $task has id $task_id, has name $task_name;
+                $student isa student, has id $student_id, has fullName $student_name;
+                $registration isa registersForTask (student: $student, task: $task);
+                $scr isa statusChangeRequest (registration: $registration),
+                    has id $scr_id,
+                    has requestType $req_type,
+                    has reason $reason,
+                    has requestStatus "pending",
+                    has createdAt $created_at;
+            fetch {
+                'id': $scr_id,
+                'request_type': $req_type,
+                'reason': $reason,
+                'created_at': $created_at,
+                'auto_approve_at': [$scr.autoApproveAt],
+                'task_id': $task_id,
+                'task_name': $task_name,
+                'project_id': $project_id,
+                'project_name': $project_name,
+                'student_id': $student_id,
+                'student_name': $student_name,
+                'requester': [
+                    match
+                        $scr_inner isa statusChangeRequest (
+                            registration: $registration,
+                            requester: $req_user
+                        ), has id $scr_id;
+                        $req_user has id $req_uid, has fullName $req_uname;
+                    fetch {
+                        'id': $req_uid,
+                        'full_name': $req_uname
+                    };
+                ]
+            };
+        """
+
+        # Try student query first, then supervisor query
+        results = []
+        try:
+            student_results = Db.read_transact(student_query, {"user_id": user_id})
+            if student_results:
+                for r in student_results:
+                    requester_list = r.get("requester", [])
+                    requester = requester_list[0] if requester_list else None
+                    # Only show requests that the student didn't initiate themselves
+                    if requester and requester.get("id") == user_id:
+                        continue
+                    auto_approve = r.get("auto_approve_at", [])
+                    results.append({
+                        "id": r.get("id"),
+                        "request_type": r.get("request_type"),
+                        "reason": r.get("reason"),
+                        "created_at": r.get("created_at"),
+                        "auto_approve_at": auto_approve[0] if auto_approve else None,
+                        "task_id": r.get("task_id"),
+                        "task_name": r.get("task_name"),
+                        "project_id": r.get("project_id"),
+                        "project_name": r.get("project_name"),
+                        "requester": requester,
+                    })
+        except Exception:
+            pass
+
+        try:
+            supervisor_results = Db.read_transact(supervisor_query, {"user_id": user_id})
+            if supervisor_results:
+                for r in supervisor_results:
+                    requester_list = r.get("requester", [])
+                    requester = requester_list[0] if requester_list else None
+                    # Only show requests that the supervisor didn't initiate themselves
+                    if requester and requester.get("id") == user_id:
+                        continue
+                    auto_approve = r.get("auto_approve_at", [])
+                    results.append({
+                        "id": r.get("id"),
+                        "request_type": r.get("request_type"),
+                        "reason": r.get("reason"),
+                        "created_at": r.get("created_at"),
+                        "auto_approve_at": auto_approve[0] if auto_approve else None,
+                        "task_id": r.get("task_id"),
+                        "task_name": r.get("task_name"),
+                        "project_id": r.get("project_id"),
+                        "project_name": r.get("project_name"),
+                        "student_id": r.get("student_id"),
+                        "student_name": r.get("student_name"),
+                        "requester": requester,
+                    })
+        except Exception:
+            pass
+
+        return results
+
+    def check_and_create_end_reviews(self) -> int:
+        """
+        Lazy check: Find all accepted registrations where:
+        - Task endDate has passed
+        - registrationStatus is NOT set (still "lopend")
+        - No pending statusChangeRequest exists
+        
+        Creates end_review requests for these.
+        Returns count of created reviews.
+        """
+        now = datetime.now()
+
+        query = """
+            match
+                $student isa student, has id $student_id;
+                $task isa task, has id $task_id, has endDate $end_date;
+                $registration isa registersForTask (student: $student, task: $task),
+                    has isAccepted true;
+                not { $registration has registrationStatus $any_status; };
+                not { $registration has completedAt $any_completed; };
+                not {
+                    $existing_scr isa statusChangeRequest (registration: $registration),
+                        has requestStatus "pending";
+                };
+            fetch {
+                'student_id': $student_id,
+                'task_id': $task_id,
+                'end_date': $end_date
+            };
+        """
+        results = Db.read_transact(query)
+        
+        created = 0
+        for r in results:
+            end_date = r.get("end_date")
+            if not end_date:
+                continue
+            
+            # Check if end_date is in the past
+            try:
+                if isinstance(end_date, str):
+                    dt = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
+                elif isinstance(end_date, datetime):
+                    dt = end_date
+                else:
+                    continue
+                
+                # Remove timezone for comparison
+                if hasattr(dt, 'tzinfo') and dt.tzinfo is not None:
+                    dt = dt.replace(tzinfo=None)
+                
+                if dt.date() < now.date():
+                    self.create_end_review(
+                        task_id=r.get("task_id"),
+                        student_id=r.get("student_id"),
+                    )
+                    created += 1
+            except (ValueError, TypeError):
+                continue
+
+        return created
+
+    def auto_approve_expired(self) -> int:
+        """
+        Lazy check: Auto-approve end_review requests where autoApproveAt has passed.
+        Sets registrationStatus to "afgerond" (default outcome).
+        Returns count of auto-approved requests.
+        """
+        now = datetime.now()
+
+        query = """
+            match
+                $scr isa statusChangeRequest,
+                    has id $scr_id,
+                    has requestType "end_review",
+                    has requestStatus "pending",
+                    has autoApproveAt $auto_date;
+            fetch {
+                'id': $scr_id,
+                'auto_approve_at': $auto_date
+            };
+        """
+        results = Db.read_transact(query)
+        
+        approved = 0
+        for r in results:
+            auto_date = r.get("auto_approve_at")
+            if not auto_date:
+                continue
+            
+            try:
+                if isinstance(auto_date, str):
+                    dt = datetime.fromisoformat(auto_date.replace("Z", "+00:00"))
+                elif isinstance(auto_date, datetime):
+                    dt = auto_date
+                else:
+                    continue
+                
+                if hasattr(dt, 'tzinfo') and dt.tzinfo is not None:
+                    dt = dt.replace(tzinfo=None)
+                
+                if dt < now:
+                    request_id = r.get("id")
+                    # Update request status to auto_approved
+                    update_query = """
+                        match
+                            $scr isa statusChangeRequest, has id ~request_id;
+                        update
+                            $scr has requestStatus "auto_approved";
+                            $scr has respondedAt ~responded_at;
+                            $scr has responseMessage "Automatisch goedgekeurd na 14 dagen zonder reactie.";
+                    """
+                    Db.write_transact(update_query, {
+                        "request_id": request_id,
+                        "responded_at": now,
+                    })
+                    
+                    # Set registration status to afgerond (default)
+                    status_query = """
+                        match
+                            $scr isa statusChangeRequest (registration: $registration),
+                                has id ~request_id;
+                        update
+                            $registration has registrationStatus "afgerond";
+                    """
+                    Db.write_transact(status_query, {
+                        "request_id": request_id,
+                    })
+                    
+                    approved += 1
+            except (ValueError, TypeError):
+                continue
+
+        return approved
+
+    def get_registration_status(self, task_id: str, student_id: str) -> str:
+        """
+        Get the current registration status for a student-task pair.
+        Returns "lopend", "afgerond", or "afgebroken".
+        Defaults to "lopend" if no explicit status is set.
+        """
+        query = """
+            match
+                $task isa task, has id ~task_id;
+                $student isa student, has id ~student_id;
+                $registration isa registersForTask (student: $student, task: $task);
+            fetch {
+                'registration_status': [$registration.registrationStatus],
+                'is_accepted': [$registration.isAccepted]
+            };
+        """
+        results = Db.read_transact(query, {
+            "task_id": task_id,
+            "student_id": student_id,
+        })
+        
+        if not results:
+            return "lopend"
+        
+        r = results[0]
+        status_list = r.get("registration_status", [])
+        if status_list:
+            return status_list[0]
+        return "lopend"

--- a/projojo_backend/main.py
+++ b/projojo_backend/main.py
@@ -32,6 +32,7 @@ from routes.task_router import router as task_router
 from routes.teacher_router import router as teacher_router
 from routes.user_router import router as user_router
 from routes.theme_router import router as theme_router
+from routes.status_change_router import router as status_change_router
 
 # Import the TypeDB connection module
 from db.initDatabase import get_database
@@ -89,6 +90,7 @@ app.include_router(task_router)
 app.include_router(teacher_router)
 app.include_router(user_router)
 app.include_router(theme_router)
+app.include_router(status_change_router)
 
 # Add exception handler for Custom exceptions
 app.add_exception_handler(ItemRetrievalException, generic_handler)

--- a/projojo_backend/routes/status_change_router.py
+++ b/projojo_backend/routes/status_change_router.py
@@ -1,0 +1,201 @@
+"""
+API endpoints for task-level status change consensus mechanism.
+
+Endpoints:
+- POST   /tasks/{task_id}/registrations/{student_id}/status-request
+- GET    /tasks/{task_id}/registrations/{student_id}/status-request
+- PATCH  /status-requests/{request_id}/respond
+- GET    /users/{user_id}/pending-status-requests
+"""
+from fastapi import APIRouter, Path, Body, HTTPException, Request, Depends
+from pydantic import BaseModel
+from typing import Optional
+from auth.permissions import auth
+from auth.jwt_utils import get_token_payload
+from domain.repositories.status_change_repository import StatusChangeRepository
+
+status_change_repo = StatusChangeRepository()
+
+router = APIRouter(tags=["Status Change Endpoints"])
+
+
+# ============================================================================
+# Request/Response Models
+# ============================================================================
+
+class StatusChangeRequestCreate(BaseModel):
+    """Body for creating a status change request."""
+    request_type: str  # "completion" | "cancellation"
+    reason: str
+
+
+class StatusChangeResponseBody(BaseModel):
+    """Body for responding to a status change request."""
+    approved: bool
+    response_message: Optional[str] = ""
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+@router.post("/tasks/{task_id}/registrations/{student_id}/status-request")
+@auth(role="authenticated")
+async def create_status_request(
+    request: Request,
+    task_id: str = Path(..., description="Task ID"),
+    student_id: str = Path(..., description="Student ID"),
+    body: StatusChangeRequestCreate = Body(...),
+):
+    """
+    Create a status change request for a task registration.
+    
+    Can be initiated by:
+    - The student themselves (for their own registration)
+    - The supervisor of the business that owns the project
+    """
+    user_id = request.state.user_id
+    user_role = request.state.user_role
+
+    # Validate request type
+    if body.request_type not in ("completion", "cancellation"):
+        raise HTTPException(
+            status_code=400,
+            detail="request_type moet 'completion' of 'cancellation' zijn"
+        )
+
+    # Authorization: student can only create for themselves
+    if user_role == "student" and user_id != student_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Je kunt alleen een verzoek indienen voor je eigen registratie"
+        )
+
+    # Check if there's already a pending request
+    existing = status_change_repo.get_pending_request(task_id, student_id)
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="Er is al een lopend statusverzoek voor deze registratie"
+        )
+
+    try:
+        result = status_change_repo.create_request(
+            task_id=task_id,
+            student_id=student_id,
+            requester_id=user_id,
+            request_type=body.request_type,
+            reason=body.reason,
+        )
+        return result
+    except Exception as e:
+        print(f"Error creating status request: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail="Er is iets misgegaan bij het aanmaken van het statusverzoek"
+        )
+
+
+@router.get("/tasks/{task_id}/registrations/{student_id}/status-request")
+@auth(role="authenticated")
+async def get_status_request(
+    task_id: str = Path(..., description="Task ID"),
+    student_id: str = Path(..., description="Student ID"),
+):
+    """
+    Get the current pending status change request for a registration.
+    Also triggers lazy checks for auto-reviews and auto-approvals.
+    """
+    # Lazy trigger: check for expired tasks and auto-approve
+    try:
+        status_change_repo.check_and_create_end_reviews()
+        status_change_repo.auto_approve_expired()
+    except Exception as e:
+        print(f"Lazy check error (non-critical): {e}")
+
+    pending = status_change_repo.get_pending_request(task_id, student_id)
+    if not pending:
+        # Return registration status even without a pending request
+        reg_status = status_change_repo.get_registration_status(task_id, student_id)
+        return {
+            "pending_request": None,
+            "registration_status": reg_status,
+        }
+
+    return {
+        "pending_request": pending,
+        "registration_status": "in_beoordeling",
+    }
+
+
+@router.patch("/status-requests/{request_id}/respond")
+@auth(role="authenticated")
+async def respond_to_status_request(
+    request: Request,
+    request_id: str = Path(..., description="Status Change Request ID"),
+    body: StatusChangeResponseBody = Body(...),
+):
+    """
+    Respond to a pending status change request (approve or deny).
+    
+    Can be responded to by:
+    - If requester was student -> supervisor responds
+    - If requester was supervisor -> student responds
+    - For end_review -> either party can respond
+    """
+    user_id = request.state.user_id
+
+    try:
+        result = status_change_repo.respond_to_request(
+            request_id=request_id,
+            responder_id=user_id,
+            approved=body.approved,
+            response_message=body.response_message or "",
+        )
+        return result
+    except Exception as e:
+        print(f"Error responding to status request: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail="Er is iets misgegaan bij het reageren op het statusverzoek"
+        )
+
+
+@router.get("/users/{user_id}/pending-status-requests")
+@auth(role="authenticated")
+async def get_pending_requests(
+    request: Request,
+    user_id: str = Path(..., description="User ID"),
+):
+    """
+    Get all pending status change requests for a user.
+    Used for the notification badge in the navbar.
+    
+    Also triggers lazy checks for auto-reviews and auto-approvals.
+    """
+    # Verify the user is requesting their own data (or is a teacher)
+    if request.state.user_id != user_id and request.state.user_role != "teacher":
+        raise HTTPException(
+            status_code=403,
+            detail="Je kunt alleen je eigen verzoeken bekijken"
+        )
+
+    # Lazy trigger: check for expired tasks and auto-approve
+    try:
+        status_change_repo.check_and_create_end_reviews()
+        status_change_repo.auto_approve_expired()
+    except Exception as e:
+        print(f"Lazy check error (non-critical): {e}")
+
+    try:
+        results = status_change_repo.get_pending_requests_for_user(user_id)
+        return {
+            "pending_requests": results,
+            "count": len(results),
+        }
+    except Exception as e:
+        print(f"Error getting pending requests: {e}")
+        raise HTTPException(
+            status_code=400,
+            detail="Er is iets misgegaan bij het ophalen van de statusverzoeken"
+        )

--- a/projojo_backend/routes/student_router.py
+++ b/projojo_backend/routes/student_router.py
@@ -206,6 +206,8 @@ async def get_student_portfolio(
         "completed_count": sum(1 for item in portfolio if item.get("source_type") == "live"),
         "active_count": sum(1 for item in portfolio if item.get("source_type") == "active"),
         "snapshot_count": sum(1 for item in portfolio if item.get("source_type") == "snapshot"),
+        "afgerond_count": sum(1 for item in portfolio if item.get("registration_status") == "afgerond"),
+        "afgebroken_count": sum(1 for item in portfolio if item.get("registration_status") == "afgebroken"),
         # Legacy fields for backwards compatibility
         "live_count": sum(1 for item in portfolio if item.get("source_type") == "live"),
     }

--- a/projojo_backend/templates/email/status_request.html
+++ b/projojo_backend/templates/email/status_request.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Statusverzoek: {{ task_name }}{% endblock %}
+
+{% block header_subtitle %}
+<p class="subtitle">Taak Statusverzoek</p>
+{% endblock %}
+
+{% block content %}
+<h2>Hallo {{ recipient_name }}!</h2>
+
+{% if request_type == "completion" %}
+<p><strong>{{ requester_name }}</strong> heeft een verzoek ingediend om de taak <strong>{{ task_name }}</strong> als <strong>afgerond</strong> te markeren.</p>
+{% elif request_type == "cancellation" %}
+<p><strong>{{ requester_name }}</strong> heeft een verzoek ingediend om de taak <strong>{{ task_name }}</strong> als <strong>afgebroken</strong> te markeren.</p>
+{% elif request_type == "end_review" %}
+<p>De taakperiode van <strong>{{ task_name }}</strong> is verstreken. Beoordeel of de taak is afgerond of afgebroken.</p>
+{% endif %}
+
+<div class="info-box">
+    <p><strong>Project:</strong> {{ project_name }}</p>
+    <p><strong>Taak:</strong> {{ task_name }}</p>
+    {% if student_name %}
+    <p><strong>Student:</strong> {{ student_name }}</p>
+    {% endif %}
+    {% if reason %}
+    <p><strong>Reden:</strong> {{ reason }}</p>
+    {% endif %}
+</div>
+
+{% if request_type == "end_review" and auto_approve_date %}
+<div class="warning-box">
+    <p>Let op: Als er niet binnen 14 dagen wordt gereageerd, wordt de taak automatisch als <strong>afgerond</strong> gemarkeerd ({{ auto_approve_date }}).</p>
+</div>
+{% endif %}
+
+{% if action_url %}
+<p style="text-align: center;">
+    <a href="{{ action_url }}" class="button">Bekijk Verzoek</a>
+</p>
+
+<p class="link-text">
+    Of kopieer deze link: {{ action_url }}
+</p>
+{% endif %}
+
+<p>Log in op Projojo om het verzoek te beoordelen en te reageren.</p>
+{% endblock %}

--- a/projojo_backend/templates/email/status_response.html
+++ b/projojo_backend/templates/email/status_response.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Statusverzoek {{ "goedgekeurd" if approved else "afgewezen" }}: {{ task_name }}{% endblock %}
+
+{% block header_subtitle %}
+<p class="subtitle">Verzoek {{ "Goedgekeurd" if approved else "Afgewezen" }}</p>
+{% endblock %}
+
+{% block content %}
+<h2>Hallo {{ recipient_name }}!</h2>
+
+{% if auto_approved %}
+<p>Het statusverzoek voor taak <strong>{{ task_name }}</strong> is <strong>automatisch goedgekeurd</strong> omdat er niet binnen 14 dagen is gereageerd.</p>
+{% elif approved %}
+<p>{{ responder_name }} heeft het statusverzoek voor taak <strong>{{ task_name }}</strong> <strong>goedgekeurd</strong>.</p>
+{% else %}
+<p>{{ responder_name }} heeft het statusverzoek voor taak <strong>{{ task_name }}</strong> <strong>afgewezen</strong>.</p>
+{% endif %}
+
+<div class="info-box">
+    <p><strong>Project:</strong> {{ project_name }}</p>
+    <p><strong>Taak:</strong> {{ task_name }}</p>
+    {% if new_status %}
+    <p><strong>Nieuwe status:</strong> {{ new_status }}</p>
+    {% endif %}
+    {% if response_message %}
+    <p><strong>Reactie:</strong> {{ response_message }}</p>
+    {% endif %}
+</div>
+
+{% if not approved %}
+<p>De taak blijft op de huidige status staan. Neem contact op als je vragen hebt.</p>
+{% endif %}
+
+{% if action_url %}
+<p style="text-align: center;">
+    <a href="{{ action_url }}" class="button">Bekijk Taak</a>
+</p>
+{% endif %}
+{% endblock %}

--- a/projojo_frontend/src/components/PortfolioItem.jsx
+++ b/projojo_frontend/src/components/PortfolioItem.jsx
@@ -15,6 +15,11 @@ export default function PortfolioItem({ item, expanded = false, onToggleExpand }
     const isLive = item.source_type === "live";
     const isArchived = item.is_archived;
     const isSnapshot = item.source_type === "snapshot";
+    const registrationStatus = item.registration_status || null;
+    const pendingRequest = item.pending_request || null;
+    const isAfgerond = registrationStatus === "afgerond";
+    const isAfgebroken = registrationStatus === "afgebroken";
+    const isInBeoordeling = !!pendingRequest;
 
     // Parse timeline
     const timeline = item.timeline || {};
@@ -68,9 +73,27 @@ export default function PortfolioItem({ item, expanded = false, onToggleExpand }
                                 {item.task_name}
                             </h3>
                             
-                            {/* Status badges */}
-                            {isArchived && (
-                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-700 dark:text-amber-400">
+                            {/* Status badges - consensus system */}
+                            {isAfgerond && (
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-700 dark:text-green-400">
+                                    <span className="material-symbols-outlined text-xs">check_circle</span>
+                                    Afgerond
+                                </span>
+                            )}
+                            {isAfgebroken && (
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-500/10 text-gray-600 dark:text-gray-400">
+                                    <span className="material-symbols-outlined text-xs">cancel</span>
+                                    Afgebroken
+                                </span>
+                            )}
+                            {isInBeoordeling && !isAfgerond && !isAfgebroken && (
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-600 dark:text-green-400">
+                                    <span className="material-symbols-outlined text-xs">hourglass_top</span>
+                                    In beoordeling
+                                </span>
+                            )}
+                            {!registrationStatus && !pendingRequest && isArchived && (
+                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-500/10 text-gray-600 dark:text-gray-400">
                                     <span className="material-symbols-outlined text-xs">inventory_2</span>
                                     Gearchiveerd
                                 </span>

--- a/projojo_frontend/src/components/PortfolioRoadmap.jsx
+++ b/projojo_frontend/src/components/PortfolioRoadmap.jsx
@@ -189,6 +189,8 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                 daysEarly,
                 isCompleted: !!timeline.completed_at,
                 isActive: !timeline.completed_at && (timeline.accepted_at || timeline.started_at),
+                registration_status: item.registration_status || null,
+                pending_request: item.pending_request || null,
             };
         }).filter(Boolean);
     }, [items, minDate, maxDate, months, monthWidth]);
@@ -269,17 +271,24 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
     }, [itemBars]);
 
     const getStatusColor = (item) => {
-        if (item.is_archived) return "bg-amber-500";
+        // New consensus-based status system
+        if (item.registration_status === "afgebroken") return "bg-gray-400";
+        if (item.registration_status === "afgerond") return "bg-green-500";
         if (item.source_type === "snapshot") return "bg-gray-400";
+        if (item.pending_request) return "bg-green-500"; // In beoordeling
         if (item.isCompleted) return "bg-green-500";
-        return "bg-blue-500";
+        if (item.isActive) return "bg-blue-500";
+        return "bg-gray-400";
     };
 
     const getStatusBgColor = (item) => {
-        if (item.is_archived) return "bg-amber-500/20";
+        if (item.registration_status === "afgebroken") return "bg-gray-400/20";
+        if (item.registration_status === "afgerond") return "bg-green-500/20";
         if (item.source_type === "snapshot") return "bg-gray-400/20";
+        if (item.pending_request) return "bg-green-500/15";
         if (item.isCompleted) return "bg-green-500/20";
-        return "bg-blue-500/20";
+        if (item.isActive) return "bg-blue-500/20";
+        return "bg-gray-400/20";
     };
 
     if (items.length === 0) {
@@ -364,19 +373,23 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                 </div>
             </div>
 
-            {/* Legend - cleaner */}
+            {/* Legend */}
             <div className="flex flex-wrap items-center gap-5 text-xs">
                 <div className="flex items-center gap-2">
                     <span className="material-symbols-outlined text-green-600 text-sm">check_circle</span>
-                    <span className="text-[var(--text-muted)]">Voltooid</span>
+                    <span className="text-[var(--text-muted)]">Afgerond</span>
                 </div>
                 <div className="flex items-center gap-2">
                     <span className="material-symbols-outlined text-blue-500 text-sm animate-pulse">pending</span>
-                    <span className="text-[var(--text-muted)]">Actief</span>
+                    <span className="text-[var(--text-muted)]">Lopend</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full bg-amber-500" />
-                    <span className="text-[var(--text-muted)]">Gearchiveerd</span>
+                    <span className="material-symbols-outlined text-gray-400 text-sm">cancel</span>
+                    <span className="text-[var(--text-muted)]">Afgebroken</span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span className="material-symbols-outlined text-green-500 text-sm">hourglass_top</span>
+                    <span className="text-[var(--text-muted)]">In beoordeling</span>
                 </div>
             </div>
 
@@ -441,14 +454,20 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                                                 />
                                             )}
                                             
-                                            {/* Work period foreground bar - clean design */}
+                                            {/* Work period foreground bar - clean design with consensus status */}
                                             <div
                                                 className={`group absolute top-0.5 h-10 rounded-lg cursor-pointer transition-all hover:scale-[1.02] hover:z-10 hover:shadow-lg ${
-                                                    item.isActive 
-                                                        ? 'bg-blue-500/25 border-2 border-blue-500/50 shadow-[0_0_8px_rgba(59,130,246,0.3)]' 
-                                                        : item.isCompleted 
-                                                            ? 'bg-green-500/20 border border-green-500/30' 
-                                                            : getStatusBgColor(item) + ' border border-[var(--neu-border)]'
+                                                    item.registration_status === "afgebroken"
+                                                        ? 'bg-gray-400/20 border border-gray-400/30'
+                                                        : item.registration_status === "afgerond"
+                                                            ? 'bg-green-500/20 border border-green-500/30'
+                                                            : item.pending_request
+                                                                ? 'bg-green-500/15 border border-dashed border-green-500/40'
+                                                                : item.isActive 
+                                                                    ? 'bg-blue-500/25 border-2 border-blue-500/50 shadow-[0_0_8px_rgba(59,130,246,0.3)]' 
+                                                                    : item.isCompleted 
+                                                                        ? 'bg-green-500/20 border border-green-500/30' 
+                                                                        : getStatusBgColor(item) + ' border border-[var(--neu-border)]'
                                                 }`}
                                                 style={{
                                                     left: `${item.leftPixels}px`,
@@ -460,8 +479,20 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                                             >
                                                 {/* Bar content - cleaner layout */}
                                                 <div className="flex items-center h-full px-3 gap-2 overflow-hidden">
-                                                    {/* Status icon - larger, at start */}
-                                                    {item.isCompleted ? (
+                                                    {/* Status icon based on consensus status */}
+                                                    {item.registration_status === "afgebroken" ? (
+                                                        <span className="material-symbols-outlined text-gray-400 text-base shrink-0">
+                                                            cancel
+                                                        </span>
+                                                    ) : item.registration_status === "afgerond" ? (
+                                                        <span className="material-symbols-outlined text-green-600 text-base shrink-0">
+                                                            check_circle
+                                                        </span>
+                                                    ) : item.pending_request ? (
+                                                        <span className="material-symbols-outlined text-green-500 text-base shrink-0 animate-pulse">
+                                                            hourglass_top
+                                                        </span>
+                                                    ) : item.isCompleted ? (
                                                         <span className="material-symbols-outlined text-green-600 text-base shrink-0">
                                                             check_circle
                                                         </span>
@@ -515,12 +546,26 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                     {/* Header with status */}
                     <div className="flex items-start gap-3 mb-3">
                         <div className={`w-12 h-12 rounded-xl flex items-center justify-center shrink-0 ${
-                            hoveredItem.isActive ? 'bg-blue-500/20' : hoveredItem.isCompleted ? 'bg-green-500/20' : getStatusBgColor(hoveredItem)
+                            hoveredItem.registration_status === "afgebroken" ? 'bg-gray-400/20'
+                            : hoveredItem.registration_status === "afgerond" ? 'bg-green-500/20'
+                            : hoveredItem.pending_request ? 'bg-green-500/15'
+                            : hoveredItem.isActive ? 'bg-blue-500/20' 
+                            : hoveredItem.isCompleted ? 'bg-green-500/20' 
+                            : getStatusBgColor(hoveredItem)
                         }`}>
                             <span className={`material-symbols-outlined text-xl ${
-                                hoveredItem.isActive ? 'text-blue-500' : hoveredItem.isCompleted ? 'text-green-600' : 'text-[var(--text-primary)]'
+                                hoveredItem.registration_status === "afgebroken" ? 'text-gray-400'
+                                : hoveredItem.registration_status === "afgerond" ? 'text-green-600'
+                                : hoveredItem.pending_request ? 'text-green-500'
+                                : hoveredItem.isActive ? 'text-blue-500' 
+                                : hoveredItem.isCompleted ? 'text-green-600' 
+                                : 'text-[var(--text-primary)]'
                             }`}>
-                                {hoveredItem.isCompleted ? 'task_alt' : hoveredItem.isActive ? 'pending' : 'schedule'}
+                                {hoveredItem.registration_status === "afgebroken" ? 'cancel' 
+                                : hoveredItem.registration_status === "afgerond" ? 'task_alt'
+                                : hoveredItem.pending_request ? 'hourglass_top'
+                                : hoveredItem.isCompleted ? 'task_alt' 
+                                : hoveredItem.isActive ? 'pending' : 'schedule'}
                             </span>
                         </div>
                         <div className="flex-1 min-w-0">
@@ -569,15 +614,31 @@ export default function PortfolioRoadmap({ items = [], studentName = "" }) {
                             {/* Completion or status */}
                             <div className="flex items-center justify-between">
                                 <span className="text-[var(--text-muted)] flex items-center gap-1">
-                                    <span className={`material-symbols-outlined text-xs ${hoveredItem.isCompleted ? 'text-green-600' : 'text-blue-500'}`}>
-                                        {hoveredItem.isCompleted ? 'check_circle' : 'pending'}
+                                    <span className={`material-symbols-outlined text-xs ${
+                                        hoveredItem.registration_status === "afgebroken" ? 'text-gray-400'
+                                        : hoveredItem.registration_status === "afgerond" ? 'text-green-600'
+                                        : hoveredItem.pending_request ? 'text-green-500'
+                                        : hoveredItem.isCompleted ? 'text-green-600' : 'text-blue-500'
+                                    }`}>
+                                        {hoveredItem.registration_status === "afgebroken" ? 'cancel'
+                                        : hoveredItem.registration_status === "afgerond" ? 'check_circle'
+                                        : hoveredItem.pending_request ? 'hourglass_top'
+                                        : hoveredItem.isCompleted ? 'check_circle' : 'pending'}
                                     </span>
-                                    {hoveredItem.isCompleted ? 'Voltooid' : 'Status'}
+                                    Status
                                 </span>
-                                <span className={`font-medium ${hoveredItem.isCompleted ? 'text-green-600' : 'text-blue-600'}`}>
-                                    {hoveredItem.timeline?.completed_at 
+                                <span className={`font-medium ${
+                                    hoveredItem.registration_status === "afgebroken" ? 'text-gray-500'
+                                    : hoveredItem.registration_status === "afgerond" ? 'text-green-600'
+                                    : hoveredItem.pending_request ? 'text-green-500'
+                                    : hoveredItem.isCompleted ? 'text-green-600' : 'text-blue-600'
+                                }`}>
+                                    {hoveredItem.registration_status === "afgebroken" ? 'Afgebroken'
+                                    : hoveredItem.registration_status === "afgerond" ? 'Afgerond'
+                                    : hoveredItem.pending_request ? 'In beoordeling'
+                                    : hoveredItem.timeline?.completed_at 
                                         ? new Date(hoveredItem.timeline.completed_at).toLocaleDateString('nl-NL', { day: 'numeric', month: 'short', year: 'numeric' })
-                                        : 'Actief'}
+                                        : 'Lopend'}
                                 </span>
                             </div>
                             {/* Deadline */}

--- a/projojo_frontend/src/components/StatusRequestBanner.jsx
+++ b/projojo_frontend/src/components/StatusRequestBanner.jsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import { respondToStatusRequest } from "../services";
+
+/**
+ * StatusRequestBanner - Shows a prominent banner for pending status change requests.
+ * Displayed on task pages where a consensus request is pending.
+ * 
+ * @param {Object} props
+ * @param {Object} props.pendingRequest - The pending status change request
+ * @param {string} props.currentUserId - The ID of the current logged-in user
+ * @param {string} props.currentUserRole - The role of the current user
+ * @param {Function} props.onResponseComplete - Callback after response is submitted
+ */
+export default function StatusRequestBanner({ 
+    pendingRequest, 
+    currentUserId, 
+    currentUserRole,
+    onResponseComplete 
+}) {
+    const [responseMessage, setResponseMessage] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [showResponseForm, setShowResponseForm] = useState(false);
+    const [selectedAction, setSelectedAction] = useState(null); // "approve" | "deny"
+
+    if (!pendingRequest) return null;
+
+    const { id, request_type, reason, requester, auto_approve_at } = pendingRequest;
+    
+    // Determine if current user initiated the request
+    const isRequester = requester?.id === currentUserId;
+    
+    // Labels based on request type
+    const typeLabels = {
+        completion: { title: "Afrondverzoek", icon: "check_circle", color: "green" },
+        cancellation: { title: "Afbreekverzoek", icon: "cancel", color: "amber" },
+        end_review: { title: "Eindbeoordeling", icon: "schedule", color: "blue" },
+    };
+    
+    const label = typeLabels[request_type] || typeLabels.end_review;
+
+    // Format auto-approve date
+    const autoApproveDate = auto_approve_at 
+        ? new Date(auto_approve_at).toLocaleDateString('nl-NL', { 
+            day: 'numeric', month: 'long', year: 'numeric' 
+        })
+        : null;
+
+    const handleSubmitResponse = async (approved) => {
+        setIsSubmitting(true);
+        try {
+            await respondToStatusRequest(id, approved, responseMessage);
+            if (onResponseComplete) {
+                onResponseComplete(approved);
+            }
+        } catch (error) {
+            console.error("Error responding to status request:", error);
+        } finally {
+            setIsSubmitting(false);
+            setShowResponseForm(false);
+        }
+    };
+
+    const bgColorClass = {
+        green: "bg-green-50 border-green-300 dark:bg-green-900/20 dark:border-green-700",
+        amber: "bg-amber-50 border-amber-300 dark:bg-amber-900/20 dark:border-amber-700",
+        blue: "bg-blue-50 border-blue-300 dark:bg-blue-900/20 dark:border-blue-700",
+    }[label.color];
+
+    const iconColorClass = {
+        green: "text-green-600 dark:text-green-400",
+        amber: "text-amber-600 dark:text-amber-400",
+        blue: "text-blue-600 dark:text-blue-400",
+    }[label.color];
+
+    return (
+        <div className={`rounded-xl border-2 p-4 mb-4 ${bgColorClass}`}>
+            {/* Header */}
+            <div className="flex items-start gap-3">
+                <span className={`material-symbols-outlined text-2xl shrink-0 ${iconColorClass}`}>
+                    {label.icon}
+                </span>
+                <div className="flex-1">
+                    <h3 className="font-semibold text-[var(--text-primary)] text-sm">
+                        {label.title}
+                        {isRequester && (
+                            <span className="ml-2 text-xs font-normal text-[var(--text-muted)]">
+                                (door jou ingediend)
+                            </span>
+                        )}
+                    </h3>
+                    
+                    {/* Request details */}
+                    <p className="text-sm text-[var(--text-secondary)] mt-1">
+                        {request_type === "end_review" 
+                            ? "De taakperiode is verstreken. Beoordeel of de taak is afgerond of afgebroken."
+                            : reason
+                        }
+                    </p>
+
+                    {requester && !isRequester && (
+                        <p className="text-xs text-[var(--text-muted)] mt-1">
+                            Ingediend door <strong>{requester.full_name}</strong>
+                        </p>
+                    )}
+
+                    {autoApproveDate && (
+                        <p className="text-xs text-[var(--text-muted)] mt-1 flex items-center gap-1">
+                            <span className="material-symbols-outlined text-xs">timer</span>
+                            Automatisch goedgekeurd op {autoApproveDate} als er niet wordt gereageerd
+                        </p>
+                    )}
+
+                    {/* Action buttons (only if not the requester) */}
+                    {!isRequester && !showResponseForm && (
+                        <div className="flex gap-2 mt-3">
+                            <button
+                                onClick={() => { setSelectedAction("approve"); setShowResponseForm(true); }}
+                                className="neu-btn-primary !rounded-lg !px-4 !py-1.5 text-sm flex items-center gap-1.5"
+                                disabled={isSubmitting}
+                            >
+                                <span className="material-symbols-outlined text-base">thumb_up</span>
+                                Akkoord
+                            </button>
+                            <button
+                                onClick={() => { setSelectedAction("deny"); setShowResponseForm(true); }}
+                                className="neu-btn !rounded-lg !px-4 !py-1.5 text-sm flex items-center gap-1.5 text-red-600"
+                                disabled={isSubmitting}
+                            >
+                                <span className="material-symbols-outlined text-base">thumb_down</span>
+                                Niet akkoord
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Response form */}
+                    {showResponseForm && (
+                        <div className="mt-3 space-y-2">
+                            <textarea
+                                value={responseMessage}
+                                onChange={(e) => setResponseMessage(e.target.value)}
+                                placeholder={selectedAction === "approve" 
+                                    ? "Optioneel: toelichting bij goedkeuring..." 
+                                    : "Geef een reden waarom je niet akkoord gaat..."
+                                }
+                                className="w-full px-3 py-2 rounded-lg neu-pressed text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-primary/50 resize-none"
+                                rows={2}
+                            />
+                            <div className="flex gap-2">
+                                <button
+                                    onClick={() => handleSubmitResponse(selectedAction === "approve")}
+                                    disabled={isSubmitting || (selectedAction === "deny" && !responseMessage.trim())}
+                                    className={`text-sm px-4 py-1.5 rounded-lg font-medium transition-colors ${
+                                        selectedAction === "approve"
+                                            ? "bg-green-600 text-white hover:bg-green-700 disabled:bg-green-400"
+                                            : "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400"
+                                    }`}
+                                >
+                                    {isSubmitting ? "Verwerken..." : (selectedAction === "approve" ? "Bevestig goedkeuring" : "Bevestig afwijzing")}
+                                </button>
+                                <button
+                                    onClick={() => { setShowResponseForm(false); setResponseMessage(""); }}
+                                    className="text-sm px-4 py-1.5 rounded-lg text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+                                    disabled={isSubmitting}
+                                >
+                                    Annuleren
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Waiting state (if requester) */}
+                    {isRequester && (
+                        <div className="flex items-center gap-2 mt-3 text-sm text-[var(--text-muted)]">
+                            <span className="material-symbols-outlined text-base animate-pulse">hourglass_top</span>
+                            Wachten op reactie van de andere partij...
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/projojo_frontend/src/components/StudentPortfolio.jsx
+++ b/projojo_frontend/src/components/StudentPortfolio.jsx
@@ -146,21 +146,29 @@ export default function StudentPortfolio({ studentId, studentName = "", isOwnPro
                             <div className="flex items-center gap-2">
                                 <span className="w-3 h-3 rounded-full bg-blue-500" />
                                 <span className="text-[var(--text-muted)]">
-                                    <strong className="text-[var(--text-primary)]">{portfolio.active_count}</strong> actief
+                                    <strong className="text-[var(--text-primary)]">{portfolio.active_count}</strong> lopend
                                 </span>
                             </div>
                         )}
-                        {portfolio.completed_count > 0 && (
+                        {(portfolio.afgerond_count || portfolio.completed_count) > 0 && (
                             <div className="flex items-center gap-2">
                                 <span className="w-3 h-3 rounded-full bg-green-500" />
                                 <span className="text-[var(--text-muted)]">
-                                    <strong className="text-[var(--text-primary)]">{portfolio.completed_count}</strong> voltooid
+                                    <strong className="text-[var(--text-primary)]">{portfolio.afgerond_count || portfolio.completed_count}</strong> afgerond
+                                </span>
+                            </div>
+                        )}
+                        {portfolio.afgebroken_count > 0 && (
+                            <div className="flex items-center gap-2">
+                                <span className="w-3 h-3 rounded-full bg-gray-400" />
+                                <span className="text-[var(--text-muted)]">
+                                    <strong className="text-[var(--text-primary)]">{portfolio.afgebroken_count}</strong> afgebroken
                                 </span>
                             </div>
                         )}
                         {portfolio.snapshot_count > 0 && (
                             <div className="flex items-center gap-2">
-                                <span className="w-3 h-3 rounded-full bg-gray-400" />
+                                <span className="w-3 h-3 rounded-full bg-gray-300" />
                                 <span className="text-[var(--text-muted)]">
                                     <strong className="text-[var(--text-primary)]">{portfolio.snapshot_count}</strong> archief
                                 </span>

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -870,3 +870,57 @@ export function markTaskCompleted(taskId, studentId) {
 export function getRegistrationTimeline(taskId, studentId) {
     return fetchWithError(`${API_BASE_URL}tasks/${taskId}/registrations/${studentId}/timeline`);
 }
+
+// ============================================================================
+// Status Change Consensus API
+// ============================================================================
+
+/**
+ * Create a status change request for a task registration (completion or cancellation)
+ * @param {string} taskId
+ * @param {string} studentId
+ * @param {string} requestType - "completion" or "cancellation"
+ * @param {string} reason
+ * @returns {Promise<{id: string, request_type: string, reason: string, request_status: string}>}
+ */
+export function requestTaskStatusChange(taskId, studentId, requestType, reason) {
+    return fetchWithError(`${API_BASE_URL}tasks/${taskId}/registrations/${studentId}/status-request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ request_type: requestType, reason }),
+    });
+}
+
+/**
+ * Get the current status request for a task registration (includes lazy auto-review check)
+ * @param {string} taskId
+ * @param {string} studentId
+ * @returns {Promise<{pending_request: object|null, registration_status: string}>}
+ */
+export function getTaskStatusRequest(taskId, studentId) {
+    return fetchWithError(`${API_BASE_URL}tasks/${taskId}/registrations/${studentId}/status-request`);
+}
+
+/**
+ * Respond to a status change request (approve or deny)
+ * @param {string} requestId
+ * @param {boolean} approved
+ * @param {string} responseMessage
+ * @returns {Promise<{id: string, request_status: string, responded_at: string}>}
+ */
+export function respondToStatusRequest(requestId, approved, responseMessage = "") {
+    return fetchWithError(`${API_BASE_URL}status-requests/${requestId}/respond`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approved, response_message: responseMessage }),
+    });
+}
+
+/**
+ * Get all pending status change requests for a user (for notification badge)
+ * @param {string} userId
+ * @returns {Promise<{pending_requests: Array, count: number}>}
+ */
+export function getPendingStatusRequests(userId) {
+    return fetchWithError(`${API_BASE_URL}users/${userId}/pending-status-requests`);
+}


### PR DESCRIPTION
## Summary

- Implements a **task-level consensus mechanism** for status changes between students and supervisors
- Three registration statuses: **Lopend** (active), **Afgerond** (completed successfully), **Afgebroken** (cancelled prematurely)
- Automatic end-of-term review when task `endDate` passes, with 14-day auto-approval to "Afgerond" if no response
- Full-stack implementation: TypeDB schema, backend API + email notifications, frontend UI across portfolio views, task details, and navbar

## Changes

### Backend
- **TypeDB schema**: New `statusChangeRequest` relation with `requestType`, `requestStatus`, `reason`, `autoApproveAt`, `registrationStatus` attributes
- **StatusChangeRepository**: CRUD for consensus requests, lazy auto-review/auto-approval checks
- **status_change_router**: REST endpoints (POST/GET/PATCH) for creating, fetching, and responding to requests
- **Email templates**: `status_request.html` and `status_response.html` for notification emails
- **student_router**: Added `afgerond_count` and `afgebroken_count` to portfolio response
- **Seed data**: All Emma registrations now have explicit `registrationStatus`

### Frontend
- **StatusRequestBanner**: New component for pending consensus request UI (approve/deny with message)
- **Task.jsx**: "Taak afronden" / "Taak afbreken" buttons for students, status banner integration
- **PortfolioRoadmap**: Updated legend with correct terminology (Afgerond, Lopend, Afgebroken, In beoordeling)
- **PortfolioList**: Consensus-based filters and empty state text
- **PortfolioItem**: Status badges for all new statuses
- **StudentPortfolio**: Stats footer with lopend/afgerond/afgebroken counts
- **Navbar**: Notification bell with pending request count (60s polling)
- **services.js**: New API functions for status change endpoints

## Test plan

- [ ] Login as Emma (student) - verify roadmap shows correct statuses and legend
- [ ] Verify "Computer Vision Fruit Analyst" shows pending completion request (hourglass icon)
- [ ] Verify "Farm Dashboard Developer" shows as afgebroken (grey cancel icon)
- [ ] Verify stats footer shows: 3 lopend, 9 afgerond, 1 afgebroken
- [ ] Navigate to a task detail page - verify "Taak afronden" / "Taak afbreken" buttons appear
- [ ] Login as supervisor of Fruitboomgaarden - verify notification badge shows pending request
- [ ] Test approve/deny flow via StatusRequestBanner
- [ ] Switch to list view - verify filters (Alle, Lopend, Afgerond, Afgebroken) work correctly


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistence schema and API workflows that mutate task registration state (including lazy auto-review/auto-approval), plus UI changes that reinterpret archived/completed status; these could affect portfolio/task status correctness and notification load.
> 
> **Overview**
> Implements a **task-level consensus workflow** for changing a `registersForTask` registration’s status to `lopend`/`afgerond`/`afgebroken`, backed by a new TypeDB `statusChangeRequest` relation (with pending/approved/denied/auto_approved states) and seeded example data.
> 
> Adds backend support via `StatusChangeRepository` + new `status_change_router` endpoints to create/fetch/respond to requests and to lazily create `end_review` requests and auto-approve them after 14 days. Portfolio APIs now return `registration_status` and any pending request, and portfolio “archived” is additionally inferred from `project.endDate` being in the past.
> 
> Updates the frontend to surface the new status model across portfolio list/roadmap/item badges, adds task-page request/approve/deny UI (`StatusRequestBanner` + modal), and shows a navbar notification badge by polling pending requests; also adds email templates and notification helpers for status-request/response emails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 981054b7adc4f73a1f7e6fe7e493c1a028bbe13c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->