### PR TITLE
bugfix teacherpage

### DIFF
--- a/projojo_frontend/src/pages/TeacherPage.jsx
+++ b/projojo_frontend/src/pages/TeacherPage.jsx
@@ -6,7 +6,6 @@ import Modal from "../components/Modal";
 import NewSkillsManagement from "../components/NewSkillsManagement";
 import PageHeader from '../components/PageHeader';
 import SkeletonList from "../components/SkeletonList";
-import Tooltip from "../components/Tooltip";
 import Alert from "../components/Alert";
 import { createNewBusiness, getBusinessesBasic, getArchivedBusinesses, archiveBusiness, restoreBusiness, IMAGE_BASE_URL } from "../services";
 
@@ -24,6 +23,7 @@ export default function TeacherPage() {
     const [archiveModalBusiness, setArchiveModalBusiness] = useState(null);
     const [isArchiving, setIsArchiving] = useState(false);
     const [showArchivedSection, setShowArchivedSection] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         if (!authData.isLoading && authData.type !== 'teacher') {
@@ -52,6 +52,8 @@ export default function TeacherPage() {
     useEffect(() => {
         let ignore = false;
 
+        setIsLoading(true);
+
         // Fetch active businesses first
         getBusinessesBasic()
             .then(data => {
@@ -61,6 +63,9 @@ export default function TeacherPage() {
             .catch(err => {
                 if (ignore) return;
                 setError(err.message);
+            })
+            .finally(() => {
+                if (!ignore) setIsLoading(false);
             })
 
         // Fetch archived businesses separately (non-blocking)
@@ -110,11 +115,7 @@ export default function TeacherPage() {
         <>
             <Alert text={error} onClose={() => setError(null)} />
             <PageHeader name={'Beheerpagina'} />
-            <div className="flex flex-wrap gap-4 justify-between mb-6">
-                <button onClick={() => openGenerateLinkModel()} className="neu-btn-primary">
-                    <span className="material-symbols-outlined text-sm mr-2">person_add</span>
-                    Nodig docenten uit
-                </button>
+            <div className="flex flex-wrap gap-4 justify-start mb-6">
                 <button onClick={() => setIsCreateBusinessModalVisible(true)} className="neu-btn-primary">
                     <span className="material-symbols-outlined text-sm mr-2">add_business</span>
                     Organisatie aanmaken
@@ -249,67 +250,6 @@ export default function TeacherPage() {
 
             <hr className="mt-8 mb-6 border-gray-200" />
             <NewSkillsManagement />
-
-            <Modal
-                modalHeader={`Collega toevoegen`}
-                isModalOpen={isModalOpen}
-                setIsModalOpen={setIsModalOpen}
-            >
-                <div className="p-4">
-                    {isLoading ?
-                        <div className='flex flex-col items-center gap-4'>
-                            <p className='font-semibold'>Aan het laden...</p>
-                            <Loading size="48px" />
-                        </div>
-                        : error ?
-                            <div className="flex flex-col items-center gap-2 text-red-600">
-                                <p className='font-semibold'>Er is iets misgegaan.</p>
-                                <p className='text-sm'>{error}</p>
-                                <button
-                                    type="button"
-                                    className="btn-primary mt-2"
-                                    onClick={openGenerateLinkModel}
-                                >
-                                    Probeer opnieuw
-                                </button>
-                            </div>
-                            : inviteLink &&
-                            <div className="flex flex-col items-center">
-                                <p className='font-semibold'>Deel de volgende link met een collega:</p>
-                                <div className='w-full flex flex-row gap-2 mt-2'>
-                                    <div className="basis-full">
-                                        <FormInput
-                                            placeholder={"Uitnodigingslink"}
-                                            readonly={true}
-                                            initialValue={inviteLink}
-                                        />
-                                    </div>
-                                    <button
-                                        className="hover:bg-gray-200 transition-colors p-2 rounded-md"
-                                        onClick={onCopyLink}
-                                        ref={toolTipRef}
-                                    >
-                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" className='w-5 h-5'><path stroke="currentColor" d="M104.6 48L64 48C28.7 48 0 76.7 0 112L0 384c0 35.3 28.7 64 64 64l96 0 0-48-96 0c-8.8 0-16-7.2-16-16l0-272c0-8.8 7.2-16 16-16l16 0c0 17.7 14.3 32 32 32l72.4 0C202 108.4 227.6 96 256 96l62 0c-7.1-27.6-32.2-48-62-48l-40.6 0C211.6 20.9 188.2 0 160 0s-51.6 20.9-55.4 48zM144 56a16 16 0 1 1 32 0 16 16 0 1 1 -32 0zM448 464l-192 0c-8.8 0-16-7.2-16-16l0-256c0-8.8 7.2-16 16-16l140.1 0L464 243.9 464 448c0 8.8-7.2 16-16 16zM256 512l192 0c35.3 0 64-28.7 64-64l0-204.1c0-12.7-5.1-24.9-14.1-33.9l-67.9-67.9c-9-9-21.2-14.1-33.9-14.1L256 128c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64z" /></svg>
-                                        <div className="sr-only">Kopieer link</div>
-                                        <Tooltip parentRef={toolTipRef}>
-                                            {tooltipText}
-                                        </Tooltip>
-                                    </button>
-
-                                </div>
-                                <p className='text-sm mt-1 text-[var(--text-secondary)] italic'>Deze link is geldig tot {formatDate(expiry)}.</p>
-                                <p className='text-sm mt-4'>De link is slechts één keer bruikbaar.</p>
-                                <button
-                                    type="button"
-                                    className="btn-primary mt-2"
-                                    onClick={openGenerateLinkModel}
-                                >
-                                    Maak een nieuwe link
-                                </button>
-                            </div>
-                    }
-                </div>
-            </Modal>
 
             {/* Archive Confirmation Modal */}
             <Modal


### PR DESCRIPTION
## Fix: TeacherPage crash – undefined variables causing blank screen

### Problem

When logging in as a teacher and navigating to "Beheer", the page rendered as a blank screen with ReferenceErrors in the console.

### Root Cause

The `TeacherPage` component referenced several variables in its JSX that were never declared:

- `isLoading` – used for the business list loading/skeleton state
- `isModalOpen` / `setIsModalOpen` – used by the "Collega toevoegen" invite modal
- `inviteLink`, `expiry`, `tooltipText`, `toolTipRef` – used inside the invite modal UI
- `openGenerateLinkModel`, `onCopyLink`, `formatDate` – functions called by the invite modal

### Changes

__`projojo_frontend/src/pages/TeacherPage.jsx`__

- Added `isLoading` state (`useState(true)`) and wired it into the `getBusinessesBasic` fetch effect (`setIsLoading(true)` before fetch, `setIsLoading(false)` in `.finally()`)
- Removed unimplemented code for "Collega toevoegen"


### Changes

#### Added business-list loading state

- Added a dedicated loading state for the active business list:

```js
const [isLoading, setIsLoading] = useState(true);
```

- Wired loading into the business fetch lifecycle:

  - `setIsLoading(true)` before fetching businesses
  - `setIsLoading(false)` in `.finally()` after the active business fetch completes
  - guarded state updates with the existing `ignore` cleanup flag to avoid updates after unmount/stale requests

This allows the existing `SkeletonList` loading UI to render safely while businesses are loading.

#### Removed incomplete teacher invite UI

Removed the unfinished teacher invite feature from `TeacherPage.jsx`, including:

- the __“Nodig docenten uit”__ button

- the __“Collega toevoegen”__ invite modal

- unused invite-related state/refs/helpers:

  - `isModalOpen`
  - `inviteLink`
  - `expiry`
  - `tooltipText`
  - `toolTipRef`
  - `formatDate`
  - `openGenerateLinkModel`
  - `onCopyLink`

- unused imports:

  - `useRef`
  - `Tooltip`
  - `Loading`

The invite-teacher UI was removed instead of stubbed because there is currently no backend support for teacher invites. The existing invite backend only supports supervisor/business invites via the `businessInvite` relation.

#### UI cleanup

- Kept the remaining __“Organisatie aanmaken”__ button on the left side of the page.

### Why

The teacher invite modal was pre-existing incomplete/dead code. Keeping it would require placeholder state and functions only to prevent crashes, while still showing users a feature that cannot actually work.

Removing the dead UI is safer because it:

- fixes the teacher admin page crash
- avoids exposing a non-functional invite feature
- reduces unused state and imports
- keeps `isLoading` scoped to the business list instead of mixing it with modal state
- leaves room to re-implement teacher invites properly later with backend support



### Notes

Teacher invites should be reintroduced in a separate feature PR once backend support exists. The existing supervisor invite implementation in `BusinessCard.jsx`, `services.js`, `invite_router.py`, and `invite_repository.py` can be used as a reference, but it should not be reused directly for teachers because it currently creates supervisor invites linked to a business.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash on the teacher admin page (`TeacherPage`) where undeclared variables referenced in JSX caused a blank screen and console ReferenceErrors. The fix adds a proper `isLoading` state for the active-business fetch and removes the incomplete invite-modal UI that was the source of all undeclared variables.

- **`isLoading` state**: Initialized to `true`, set back to `true` at the start of the business-list fetch effect, and cleared in `.finally()` behind the existing `ignore` guard — correctly scoped to the active-business list so the `SkeletonList` renders safely.
- **Dead invite modal removed**: The "Collega toevoegen" modal and its associated undeclared state (`isModalOpen`, `inviteLink`, `expiry`, `tooltipText`, `toolTipRef`) and helpers (`openGenerateLinkModel`, `onCopyLink`, `formatDate`) are deleted outright rather than stubbed, since there is no backend support for teacher invites today. The `Tooltip` import is cleaned up accordingly.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it removes broken code and adds a tightly scoped loading state with no new logic paths.

The fix is minimal and targeted: a single useState addition wired correctly into an existing fetch effect, and a wholesale removal of dead UI that caused the crash. The ignore-guard is applied consistently in .finally(), archived-business loading is intentionally non-blocking, and no new state interactions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| projojo_frontend/src/pages/TeacherPage.jsx | Fixes blank-screen crash by adding `isLoading` state for the active-business fetch and removing the broken invite-modal UI that referenced undeclared variables (`isModalOpen`, `inviteLink`, `openGenerateLinkModel`, etc.). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TeacherPage mounts] --> B[isLoading = true]
    B --> C[getBusinessesBasic]
    B --> D[getArchivedBusinesses]
    C -->|success| E[setBusinesses]
    C -->|error| F[setError]
    E --> G[.finally: setIsLoading false]
    F --> G
    G --> H{isLoading?}
    H -->|yes| I[SkeletonList]
    H -->|no, empty| J[Empty state]
    H -->|no, data| K[Business grid]
    D -->|success| L[setArchivedBusinesses]
    D -->|error| M[setArchivedBusinesses empty]
    L --> N[Archived section renders when toggled]
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TeacherPage mounts] --> B[isLoading = true]
    B --> C[getBusinessesBasic]
    B --> D[getArchivedBusinesses]
    C -->|success| E[setBusinesses]
    C -->|error| F[setError]
    E --> G[.finally: setIsLoading false]
    F --> G
    G --> H{isLoading?}
    H -->|yes| I[SkeletonList]
    H -->|no, empty| J[Empty state]
    H -->|no, data| K[Business grid]
    D -->|success| L[setArchivedBusinesses]
    D -->|error| M[setArchivedBusinesses empty]
    L --> N[Archived section renders when toggled]
    M --> N
```

</a>

<sub>Reviews (1): Last reviewed commit: ["bugfix teacherpage"](https://github.com/han-aim-cmd-wg/projojo/commit/83b11e91a9cb0d13a3108341f324d3ff8784ca02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39405800)</sub>

<!-- /greptile_comment -->