### PR TITLE
Next UI TS-010 and TS-011

### DIFF
--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -122,7 +122,7 @@ class ThemeRepository(BaseRepository[Theme]):
             "icon": theme.icon,
             "description": theme.description,
             "color": theme.color,
-            "display_order": theme.display_order
+            "display_order": display_order
         })
 
         return Theme(
@@ -132,7 +132,7 @@ class ThemeRepository(BaseRepository[Theme]):
             icon=theme.icon,
             description=theme.description,
             color=theme.color,
-            display_order=theme.display_order
+            display_order=display_order
         )
 
     def update(self, theme_id: str, theme: ThemeUpdate) -> Theme:

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -54,15 +54,16 @@ class ThemeRepository(BaseRepository[Theme]):
         # last (a real 0 sorts first), matching the frontend's `?? 999` semantics.
         return sorted(themes, key=lambda t: (999 if t.display_order is None else t.display_order, t.name))
 
-    def get_by_name_case_insensitive(self, name: str) -> Theme | None:
+    @staticmethod
+    def _find_by_name_case_insensitive(themes: list[Theme], name: str) -> Theme | None:
         # Compare in Python instead of a TypeQL `like` regex: names may contain
         # characters (spaces, '&', ...) that TypeDB's regex literal parser rejects
         # when escaped via re.escape, and the theme catalog is small.
         target = name.casefold()
-        for theme in self.get_all():
-            if theme.name.casefold() == target:
-                return theme
-        return None
+        return next((theme for theme in themes if theme.name.casefold() == target), None)
+
+    def get_by_name_case_insensitive(self, name: str) -> Theme | None:
+        return self._find_by_name_case_insensitive(self.get_all(), name)
 
     def _map_to_model(self, result: dict[str, Any]) -> Theme:
         sdg_code_list = result.get("sdg_code", [])
@@ -81,7 +82,8 @@ class ThemeRepository(BaseRepository[Theme]):
             display_order=display_order_list[0] if display_order_list else None
         )
 
-    def _next_display_order(self) -> int:
+    @staticmethod
+    def _next_display_order(themes: list[Theme]) -> int:
         """
         The display_order a new theme gets when the caller does not supply one:
         max(existing display_order) + 1.
@@ -89,18 +91,22 @@ class ThemeRepository(BaseRepository[Theme]):
         `default=0` keeps an empty catalog valid (max() of an empty sequence
         raises), so the first theme in an empty catalog becomes 1.
         """
-        orders = [theme.display_order for theme in self.get_all() if theme.display_order is not None]
+        orders = [theme.display_order for theme in themes if theme.display_order is not None]
         return max(orders, default=0) + 1
 
     def create(self, theme: ThemeCreate) -> Theme:
-        if self.get_by_name_case_insensitive(theme.name):
+        # One read of the catalog serves both the duplicate check and the
+        # display_order assignment, so they also decide against the same snapshot.
+        existing = self.get_all()
+
+        if self._find_by_name_case_insensitive(existing, theme.name):
             raise ValueError("Er bestaat al een thema met deze naam")
 
         # The teacher never picks a sort order (TS-task-011 AC-3). When the caller
         # omits display_order the server assigns it here, from the authoritative
         # catalog, instead of trusting a client that may hold a stale or empty
         # list. An explicit display_order (including 0) is always honoured.
-        display_order = theme.display_order if theme.display_order is not None else self._next_display_order()
+        display_order = theme.display_order if theme.display_order is not None else self._next_display_order(existing)
 
         id = generate_uuid()
 

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typedb.common.exception import TypeDBDriverException
 from db.initDatabase import Db, build_query
 from exceptions import ItemRetrievalException
 from .base import BaseRepository
@@ -121,15 +122,27 @@ class ThemeRepository(BaseRepository[Theme]):
                 has color ~color,
                 has displayOrder ~display_order;
         """
-        Db.write_transact(query, {
-            "id": id,
-            "name": theme.name,
-            "sdg_code": theme.sdg_code,
-            "icon": theme.icon,
-            "description": theme.description,
-            "color": theme.color,
-            "display_order": display_order
-        })
+        try:
+            Db.write_transact(query, {
+                "id": id,
+                "name": theme.name,
+                "sdg_code": theme.sdg_code,
+                "icon": theme.icon,
+                "description": theme.description,
+                "color": theme.color,
+                "display_order": display_order
+            })
+        except TypeDBDriverException:
+            # TOCTOU backstop: the duplicate check above runs against a snapshot,
+            # so two concurrent creates with the same name can both pass it; the
+            # schema's `@unique` on name then rejects the losing insert at commit.
+            # Re-checking (rather than matching the driver's error text) keeps this
+            # robust to server message changes and avoids masking unrelated write
+            # failures as a name conflict. If the name now exists, surface the same
+            # ValueError the pre-check raises (clean 4xx); otherwise re-raise.
+            if self._find_by_name_case_insensitive(self.get_all(), theme.name):
+                raise ValueError("Er bestaat al een thema met deze naam") from None
+            raise
 
         return Theme(
             id=id,

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -50,8 +50,9 @@ class ThemeRepository(BaseRepository[Theme]):
         """
         results = Db.read_transact(query)
         themes = [self._map_to_model(result) for result in results]
-        # Sort by display_order, then name
-        return sorted(themes, key=lambda t: (t.display_order or 999, t.name))
+        # Sort by display_order, then name. Treat only a missing display_order as
+        # last (a real 0 sorts first), matching the frontend's `?? 999` semantics.
+        return sorted(themes, key=lambda t: (999 if t.display_order is None else t.display_order, t.name))
 
     def get_by_name_case_insensitive(self, name: str) -> Theme | None:
         # Compare in Python instead of a TypeQL `like` regex: names may contain

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -81,12 +81,29 @@ class ThemeRepository(BaseRepository[Theme]):
             display_order=display_order_list[0] if display_order_list else None
         )
 
+    def _next_display_order(self) -> int:
+        """
+        The display_order a new theme gets when the caller does not supply one:
+        max(existing display_order) + 1.
+
+        `default=0` keeps an empty catalog valid (max() of an empty sequence
+        raises), so the first theme in an empty catalog becomes 1.
+        """
+        orders = [theme.display_order for theme in self.get_all() if theme.display_order is not None]
+        return max(orders, default=0) + 1
+
     def create(self, theme: ThemeCreate) -> Theme:
         if self.get_by_name_case_insensitive(theme.name):
             raise ValueError("Er bestaat al een thema met deze naam")
 
+        # The teacher never picks a sort order (TS-task-011 AC-3). When the caller
+        # omits display_order the server assigns it here, from the authoritative
+        # catalog, instead of trusting a client that may hold a stale or empty
+        # list. An explicit display_order (including 0) is always honoured.
+        display_order = theme.display_order if theme.display_order is not None else self._next_display_order()
+
         id = generate_uuid()
-        
+
         query = """
             insert
                 $theme isa theme,

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -163,7 +163,7 @@ class ThemeRepository(BaseRepository[Theme]):
                 $theme isa theme, has id ~theme_id;
                 $hasTheme isa hasTheme(theme: $theme);
             delete
-                $hasTheme isa hasTheme;
+                $hasTheme;
         """
         try:
             Db.write_transact(delete_relations, {"theme_id": theme_id})
@@ -175,7 +175,7 @@ class ThemeRepository(BaseRepository[Theme]):
             match
                 $theme isa theme, has id ~theme_id;
             delete
-                $theme isa theme;
+                $theme;
         """
         Db.write_transact(delete_theme, {"theme_id": theme_id})
 

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -93,7 +93,7 @@ export default function ThemeCreateModal({ isOpen, onClose, existingThemes = [],
         const payload = { name: form.name.trim(), color: form.color, display_order: nextDisplayOrder };
         if (sdgCode) payload.sdg_code = sdgCode;
         if (form.icon) payload.icon = form.icon;
-        if (form.description.trim()) payload.description = form.description;
+        if (form.description.trim()) payload.description = form.description.trim();
 
         try {
             const created = await createTheme(payload);

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -51,13 +51,16 @@ const EMPTY_FORM = { name: "", description: "", sdgCodes: [], icon: "", color: D
 /**
  * Teacher-facing "Nieuw thema" create form (TS-task-011).
  *
+ * display_order is deliberately not sent: the server assigns max(existing) + 1
+ * from the authoritative catalog (TS-task-011 AC-3). Computing it here would
+ * mean trusting a theme list that may still be loading or have failed to load.
+ *
  * @param {object} props
  * @param {boolean} props.isOpen
  * @param {() => void} props.onClose
- * @param {{display_order?: number}[]} props.existingThemes  used to auto-assign display_order
  * @param {(theme: object) => void} props.onCreated
  */
-export default function ThemeCreateModal({ isOpen, onClose, existingThemes = [], onCreated }) {
+export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
     const [form, setForm] = useState(EMPTY_FORM);
     const [error, setError] = useState(null);
     const [isSaving, setIsSaving] = useState(false);
@@ -80,8 +83,6 @@ export default function ThemeCreateModal({ isOpen, onClose, existingThemes = [],
         if (iconDetailsRef.current) iconDetailsRef.current.open = false;
     };
 
-    const nextDisplayOrder = Math.max(0, ...existingThemes.map(theme => theme.display_order ?? 0)) + 1;
-
     const handleSave = async () => {
         if (isSaving) return;
         setIsSaving(true);
@@ -90,7 +91,7 @@ export default function ThemeCreateModal({ isOpen, onClose, existingThemes = [],
         // Keep SDG codes in canonical SDG1..SDG17 order regardless of click order.
         const sdgCode = SDG_OPTIONS.filter(option => form.sdgCodes.includes(option.code)).map(option => option.code).join(",");
 
-        const payload = { name: form.name.trim(), color: form.color, display_order: nextDisplayOrder };
+        const payload = { name: form.name.trim(), color: form.color };
         if (sdgCode) payload.sdg_code = sdgCode;
         if (form.icon) payload.icon = form.icon;
         if (form.description.trim()) payload.description = form.description.trim();

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -242,7 +242,7 @@ export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
                 </div>
 
                 {error && (
-                    <p data-testid="theme-form-error" className="text-red-600 bg-red-50 p-3 rounded-md border border-red-200 text-sm">{error}</p>
+                    <p role="alert" data-testid="theme-form-error" className="text-red-600 bg-red-50 p-3 rounded-md border border-red-200 text-sm">{error}</p>
                 )}
 
                 <div className="flex gap-3 pt-1">

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -1,0 +1,259 @@
+import { useRef, useState } from "react";
+import { createTheme } from "../services";
+import Modal from "./Modal";
+
+const DESCRIPTION_MAX_LENGTH = 500;
+const DEFAULT_COLOR = "#4caf50";
+
+// SDG1–SDG17 with their Dutch labels (THEME_SDG_IMPLEMENTATION_PLAN.md §3.1).
+const SDG_OPTIONS = [
+    { code: "SDG1", label: "Geen armoede" },
+    { code: "SDG2", label: "Geen honger" },
+    { code: "SDG3", label: "Goede gezondheid en welzijn" },
+    { code: "SDG4", label: "Kwaliteitsonderwijs" },
+    { code: "SDG5", label: "Gendergelijkheid" },
+    { code: "SDG6", label: "Schoon water en sanitair" },
+    { code: "SDG7", label: "Betaalbare en duurzame energie" },
+    { code: "SDG8", label: "Waardig werk en economische groei" },
+    { code: "SDG9", label: "Industrie, innovatie en infrastructuur" },
+    { code: "SDG10", label: "Ongelijkheid verminderen" },
+    { code: "SDG11", label: "Duurzame steden en gemeenschappen" },
+    { code: "SDG12", label: "Verantwoorde consumptie en productie" },
+    { code: "SDG13", label: "Klimaatactie" },
+    { code: "SDG14", label: "Leven in het water" },
+    { code: "SDG15", label: "Leven op het land" },
+    { code: "SDG16", label: "Vrede, justitie en sterke instellingen" },
+    { code: "SDG17", label: "Partnerschap om doelstellingen te bereiken" },
+];
+
+// Curated Material Symbols icons relevant to themes (sustainability, nature,
+// education, technology, society, economy, infrastructure).
+const ICON_OPTIONS = [
+    "eco", "recycling", "forest", "park", "energy_savings_leaf", "compost",
+    "solar_power", "wind_power", "water_drop", "waves", "air", "cloud",
+    "wb_sunny", "bolt", "local_florist", "spa", "grass", "nature",
+    "pets", "cruelty_free", "agriculture", "yard", "potted_plant", "hive",
+    "thermostat", "filter_hdr", "terrain", "volcano", "tsunami", "flood",
+    "school", "menu_book", "book", "auto_stories", "science", "biotech",
+    "calculate", "functions", "history_edu", "psychology", "backpack", "draw",
+    "palette", "brush", "architecture", "engineering", "construction", "lightbulb",
+    "memory", "developer_board", "computer", "smartphone", "devices", "hub",
+    "sensors", "precision_manufacturing", "rocket_launch", "code", "terminal", "wifi",
+    "smart_toy", "api", "favorite", "health_and_safety", "medical_services", "vaccines",
+    "volunteer_activism", "diversity_3", "groups", "handshake", "public", "balance",
+    "gavel", "accessibility_new", "elderly", "emoji_people", "sign_language", "work",
+    "business_center", "factory", "storefront", "savings", "payments", "trending_up",
+    "insights", "analytics", "workspace_premium", "verified", "emoji_events", "category",
+];
+
+const EMPTY_FORM = { name: "", description: "", sdgCodes: [], icon: "", color: DEFAULT_COLOR };
+
+/**
+ * Teacher-facing "Nieuw thema" create form (TS-task-011).
+ *
+ * @param {object} props
+ * @param {boolean} props.isOpen
+ * @param {() => void} props.onClose
+ * @param {{display_order?: number}[]} props.existingThemes  used to auto-assign display_order
+ * @param {(theme: object) => void} props.onCreated
+ */
+export default function ThemeCreateModal({ isOpen, onClose, existingThemes = [], onCreated }) {
+    const [form, setForm] = useState(EMPTY_FORM);
+    const [error, setError] = useState(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const iconDetailsRef = useRef(null);
+
+    const update = (patch) => setForm(current => ({ ...current, ...patch }));
+
+    const close = () => {
+        setForm(EMPTY_FORM);
+        setError(null);
+        onClose();
+    };
+
+    const toggleSdg = (code) => {
+        update({ sdgCodes: form.sdgCodes.includes(code) ? form.sdgCodes.filter(c => c !== code) : [...form.sdgCodes, code] });
+    };
+
+    const selectIcon = (name) => {
+        update({ icon: name });
+        if (iconDetailsRef.current) iconDetailsRef.current.open = false;
+    };
+
+    const nextDisplayOrder = Math.max(0, ...existingThemes.map(theme => theme.display_order ?? 0)) + 1;
+
+    const handleSave = async () => {
+        if (isSaving) return;
+        setIsSaving(true);
+        setError(null);
+
+        // Keep SDG codes in canonical SDG1..SDG17 order regardless of click order.
+        const sdgCode = SDG_OPTIONS.filter(option => form.sdgCodes.includes(option.code)).map(option => option.code).join(",");
+
+        const payload = { name: form.name.trim(), color: form.color, display_order: nextDisplayOrder };
+        if (sdgCode) payload.sdg_code = sdgCode;
+        if (form.icon) payload.icon = form.icon;
+        if (form.description.trim()) payload.description = form.description;
+
+        try {
+            const created = await createTheme(payload);
+            onCreated?.(created);
+            close();
+        } catch (err) {
+            setError(err?.message || "Er is iets misgegaan bij het aanmaken van het thema.");
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const sdgSummary = form.sdgCodes.length
+        ? SDG_OPTIONS.filter(option => form.sdgCodes.includes(option.code)).map(option => option.code).join(", ")
+        : "Selecteer SDG('s)";
+
+    return (
+        <Modal
+            isModalOpen={isOpen}
+            setIsModalOpen={close}
+            modalHeader="Nieuw thema"
+            modalSubtitle="Voeg een thema toe aan de catalogus"
+            modalIcon="category"
+            maxWidth="max-w-lg"
+        >
+            <div data-testid="theme-create-modal" className="flex flex-col gap-4">
+                {/* Naam */}
+                <div>
+                    <label htmlFor="theme-name" className="text-sm font-bold leading-6 text-text-primary block mb-1">
+                        Naam <span className="text-primary">*</span>
+                    </label>
+                    <input
+                        id="theme-name"
+                        data-testid="theme-name-input"
+                        type="text"
+                        required
+                        maxLength={100}
+                        className="neu-input w-full"
+                        placeholder="Bijv. Duurzaamheid"
+                        value={form.name}
+                        onChange={e => update({ name: e.target.value })}
+                    />
+                </div>
+
+                {/* Beschrijving */}
+                <div>
+                    <div className="flex items-center justify-between mb-1">
+                        <label htmlFor="theme-description" className="text-sm font-bold leading-6 text-text-primary">Beschrijving</label>
+                        <span data-testid="theme-description-counter" className="text-xs text-[var(--text-muted)]">
+                            {form.description.length}/{DESCRIPTION_MAX_LENGTH}
+                        </span>
+                    </div>
+                    <textarea
+                        id="theme-description"
+                        data-testid="theme-description-input"
+                        rows={3}
+                        maxLength={DESCRIPTION_MAX_LENGTH}
+                        className="neu-input w-full"
+                        placeholder="Optionele beschrijving van het thema…"
+                        value={form.description}
+                        onChange={e => update({ description: e.target.value })}
+                    />
+                </div>
+
+                {/* SDG Code(s) */}
+                <div>
+                    <span className="text-sm font-bold leading-6 text-text-primary block mb-1">SDG Code(s)</span>
+                    <details className="neu-pressed rounded-xl overflow-hidden">
+                        <summary
+                            data-testid="theme-sdg-trigger"
+                            className="flex items-center justify-between px-4 py-2.5 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-[var(--text-secondary)]"
+                        >
+                            <span>{sdgSummary}</span>
+                            <span className="material-symbols-outlined text-base" aria-hidden="true">expand_more</span>
+                        </summary>
+                        <ul className="max-h-52 overflow-y-auto px-2 pb-2">
+                            {SDG_OPTIONS.map(option => (
+                                <li key={option.code}>
+                                    <label data-testid={`theme-sdg-option-${option.code}`} className="flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-[var(--gray-200)]/50 cursor-pointer">
+                                        <input
+                                            type="checkbox"
+                                            data-testid={`theme-sdg-checkbox-${option.code}`}
+                                            className="w-4 h-4 accent-primary rounded"
+                                            checked={form.sdgCodes.includes(option.code)}
+                                            onChange={() => toggleSdg(option.code)}
+                                        />
+                                        <span className="text-sm text-[var(--text-primary)]">{option.code} — {option.label}</span>
+                                    </label>
+                                </li>
+                            ))}
+                        </ul>
+                    </details>
+                </div>
+
+                {/* Icoon */}
+                <div>
+                    <span className="text-sm font-bold leading-6 text-text-primary block mb-1">Icoon</span>
+                    <details ref={iconDetailsRef} className="neu-pressed rounded-xl overflow-hidden">
+                        <summary
+                            data-testid="theme-icon-trigger"
+                            className="flex items-center justify-between px-4 py-2.5 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-[var(--text-secondary)]"
+                        >
+                            <span className="flex items-center gap-2">
+                                {form.icon
+                                    ? <><span className="material-symbols-outlined text-primary" aria-hidden="true">{form.icon}</span>{form.icon}</>
+                                    : "Selecteer een icoon"}
+                            </span>
+                            <span className="material-symbols-outlined text-base" aria-hidden="true">expand_more</span>
+                        </summary>
+                        <div className="max-h-52 overflow-y-auto grid grid-cols-2 gap-1 px-2 pb-2">
+                            {ICON_OPTIONS.map(name => (
+                                <button
+                                    key={name}
+                                    type="button"
+                                    data-testid="theme-icon-option"
+                                    onClick={() => selectIcon(name)}
+                                    className={`flex items-center gap-2 px-2 py-1.5 rounded-lg text-left hover:bg-[var(--gray-200)]/50 ${form.icon === name ? "bg-primary/10" : ""}`}
+                                >
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">{name}</span>
+                                    <span className="text-sm text-[var(--text-primary)] truncate">{name}</span>
+                                </button>
+                            ))}
+                        </div>
+                    </details>
+                </div>
+
+                {/* Kleur */}
+                <div>
+                    <label htmlFor="theme-color" className="text-sm font-bold leading-6 text-text-primary block mb-1">Kleur</label>
+                    <div className="flex items-center gap-3">
+                        <input
+                            id="theme-color"
+                            data-testid="theme-color-input"
+                            type="color"
+                            className="w-12 h-10 rounded-lg neu-pressed cursor-pointer"
+                            value={form.color}
+                            onChange={e => update({ color: e.target.value })}
+                        />
+                        <span data-testid="theme-color-hex" className="text-sm font-mono text-[var(--text-secondary)]">{form.color}</span>
+                    </div>
+                </div>
+
+                {error && (
+                    <p data-testid="theme-form-error" className="text-red-600 bg-red-50 p-3 rounded-md border border-red-200 text-sm">{error}</p>
+                )}
+
+                <div className="flex gap-3 pt-1">
+                    <button type="button" data-testid="theme-cancel-button" onClick={close} className="neu-btn flex-1 justify-center">
+                        Annuleren
+                    </button>
+                    <button type="button" data-testid="theme-save-button" onClick={handleSave} disabled={isSaving} className="neu-btn-primary flex-1 justify-center">
+                        {isSaving ? (
+                            <>
+                                <span className="material-symbols-outlined text-sm animate-spin mr-1" aria-hidden="true">hourglass_empty</span>
+                                Bezig…
+                            </>
+                        ) : "Opslaan"}
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -85,6 +85,10 @@ export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
 
     const handleSave = async () => {
         if (isSaving) return;
+        if (!form.name.trim()) {
+            setError("Naam is verplicht");
+            return;
+        }
         setIsSaving(true);
         setError(null);
 
@@ -120,7 +124,7 @@ export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
             modalIcon="category"
             maxWidth="max-w-lg"
         >
-            <div data-testid="theme-create-modal" className="flex flex-col gap-4">
+            <form data-testid="theme-create-modal" className="flex flex-col gap-4" onSubmit={e => { e.preventDefault(); handleSave(); }}>
                 {/* Naam */}
                 <div>
                     <label htmlFor="theme-name" className="text-sm font-bold leading-6 text-text-primary block mb-1">
@@ -245,7 +249,7 @@ export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
                     <button type="button" data-testid="theme-cancel-button" onClick={close} className="neu-btn flex-1 justify-center">
                         Annuleren
                     </button>
-                    <button type="button" data-testid="theme-save-button" onClick={handleSave} disabled={isSaving} className="neu-btn-primary flex-1 justify-center">
+                    <button type="submit" data-testid="theme-save-button" disabled={isSaving} className="neu-btn-primary flex-1 justify-center">
                         {isSaving ? (
                             <>
                                 <span className="material-symbols-outlined text-sm animate-spin mr-1" aria-hidden="true">hourglass_empty</span>
@@ -254,7 +258,7 @@ export default function ThemeCreateModal({ isOpen, onClose, onCreated }) {
                         ) : "Opslaan"}
                     </button>
                 </div>
-            </div>
+            </form>
         </Modal>
     );
 }

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { getThemes } from "../services";
 import Alert from "./Alert";
 import Loading from "./Loading";
+import ThemeCreateModal from "./ThemeCreateModal";
+import { notification } from "./notifications/NotifySystem";
 
 const DESCRIPTION_MAX_LENGTH = 100;
 
@@ -12,17 +14,24 @@ function truncateDescription(text) {
         : text;
 }
 
+function sortThemes(list) {
+    return [...(list || [])].sort(
+        (a, b) => (a.display_order ?? 999) - (b.display_order ?? 999) || a.name.localeCompare(b.name)
+    );
+}
+
 /**
  * Teacher-facing overview of the theme catalog (TS-task-010, read/display only).
  *
- * The "Nieuw thema", "Bewerken" and "Verwijderen" actions are intentionally
- * inert here: creating, editing and deleting themes are handled by TS-task-011,
- * TS-task-012 and TS-task-013 respectively.
+ * Creating a theme is handled by the "Nieuw thema" button (TS-task-011). The
+ * per-row "Bewerken" and "Verwijderen" actions are still inert here: editing
+ * and deleting are handled by TS-task-012 and TS-task-013 respectively.
  */
 export default function ThemeManagement() {
     const [themes, setThemes] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
 
     useEffect(() => {
         let ignore = false;
@@ -30,10 +39,7 @@ export default function ThemeManagement() {
         getThemes()
             .then(data => {
                 if (ignore) return;
-                const sorted = [...(data || [])].sort(
-                    (a, b) => (a.display_order ?? 999) - (b.display_order ?? 999) || a.name.localeCompare(b.name)
-                );
-                setThemes(sorted);
+                setThemes(sortThemes(data));
             })
             .catch(() => {
                 if (ignore) return;
@@ -60,7 +66,7 @@ export default function ThemeManagement() {
                         Er {themes.length === 1 ? "is" : "zijn"} <strong className="text-primary">{themes.length}</strong> thema{themes.length !== 1 ? "'s" : ""} in de catalogus.
                     </p>
                 </div>
-                <button type="button" className="neu-btn-primary">
+                <button type="button" className="neu-btn-primary" onClick={() => setIsCreateOpen(true)}>
                     <span className="material-symbols-outlined text-sm mr-2" aria-hidden="true">add</span>
                     Nieuw thema
                 </button>
@@ -142,6 +148,16 @@ export default function ThemeManagement() {
                     </table>
                 </div>
             )}
+
+            <ThemeCreateModal
+                isOpen={isCreateOpen}
+                onClose={() => setIsCreateOpen(false)}
+                existingThemes={themes}
+                onCreated={theme => {
+                    setThemes(prev => sortThemes([...prev, theme]));
+                    notification.success("Thema aangemaakt");
+                }}
+            />
         </section>
     );
 }

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -62,9 +62,11 @@ export default function ThemeManagement() {
                         <span className="material-symbols-outlined text-primary" aria-hidden="true">category</span>
                         Thema&apos;s
                     </h2>
-                    <p className="text-[var(--text-muted)] mt-1">
-                        Er {themes.length === 1 ? "is" : "zijn"} <strong className="text-primary">{themes.length}</strong> thema{themes.length !== 1 ? "'s" : ""} in de catalogus.
-                    </p>
+                    {!isLoading && !error && (
+                        <p className="text-[var(--text-muted)] mt-1">
+                            Er {themes.length === 1 ? "is" : "zijn"} <strong className="text-primary">{themes.length}</strong> thema{themes.length !== 1 ? "'s" : ""} in de catalogus.
+                        </p>
+                    )}
                 </div>
                 <button type="button" className="neu-btn-primary" onClick={() => setIsCreateOpen(true)}>
                     <span className="material-symbols-outlined text-sm mr-2" aria-hidden="true">add</span>

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -5,12 +5,12 @@ import Loading from "./Loading";
 import ThemeCreateModal from "./ThemeCreateModal";
 import { notification } from "./notifications/NotifySystem";
 
-const DESCRIPTION_MAX_LENGTH = 100;
+const DESCRIPTION_TRUNCATE_LENGTH = 100;
 
 function truncateDescription(text) {
     if (!text) return "";
-    return text.length > DESCRIPTION_MAX_LENGTH
-        ? `${text.slice(0, DESCRIPTION_MAX_LENGTH).trimEnd()}…`
+    return text.length > DESCRIPTION_TRUNCATE_LENGTH
+        ? `${text.slice(0, DESCRIPTION_TRUNCATE_LENGTH).trimEnd()}…`
         : text;
 }
 

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { getThemes } from "../services";
+import Alert from "./Alert";
+import Loading from "./Loading";
+
+const DESCRIPTION_MAX_LENGTH = 100;
+
+function truncateDescription(text) {
+    if (!text) return "";
+    return text.length > DESCRIPTION_MAX_LENGTH
+        ? `${text.slice(0, DESCRIPTION_MAX_LENGTH).trimEnd()}…`
+        : text;
+}
+
+/**
+ * Teacher-facing overview of the theme catalog (TS-task-010, read/display only).
+ *
+ * The "Nieuw thema", "Bewerken" and "Verwijderen" actions are intentionally
+ * inert here: creating, editing and deleting themes are handled by TS-task-011,
+ * TS-task-012 and TS-task-013 respectively.
+ */
+export default function ThemeManagement() {
+    const [themes, setThemes] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        let ignore = false;
+
+        getThemes()
+            .then(data => {
+                if (ignore) return;
+                const sorted = [...(data || [])].sort(
+                    (a, b) => (a.display_order ?? 999) - (b.display_order ?? 999) || a.name.localeCompare(b.name)
+                );
+                setThemes(sorted);
+            })
+            .catch(() => {
+                if (ignore) return;
+                setError("Er is iets misgegaan bij het ophalen van de thema's.");
+            })
+            .finally(() => {
+                if (!ignore) setIsLoading(false);
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
+
+    return (
+        <section data-testid="theme-management" className="flex flex-col gap-6">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                    <h2 className="text-2xl font-extrabold text-[var(--text-primary)] flex items-center gap-2">
+                        <span className="material-symbols-outlined text-primary" aria-hidden="true">category</span>
+                        Thema&apos;s
+                    </h2>
+                    <p className="text-[var(--text-muted)] mt-1">
+                        Er {themes.length === 1 ? "is" : "zijn"} <strong className="text-primary">{themes.length}</strong> thema{themes.length !== 1 ? "'s" : ""} in de catalogus.
+                    </p>
+                </div>
+                <button type="button" className="neu-btn-primary">
+                    <span className="material-symbols-outlined text-sm mr-2" aria-hidden="true">add</span>
+                    Nieuw thema
+                </button>
+            </div>
+
+            {isLoading ? (
+                <div data-testid="theme-loading" role="status" className="neu-flat rounded-2xl p-8">
+                    <span className="sr-only">Thema&apos;s laden…</span>
+                    <Loading />
+                </div>
+            ) : error ? (
+                <Alert text={error} isCloseable={false} />
+            ) : themes.length === 0 ? (
+                <div data-testid="theme-empty" className="neu-pressed p-8 text-center">
+                    <span className="material-symbols-outlined text-4xl text-gray-300 mb-2 block" aria-hidden="true">category</span>
+                    <p className="text-[var(--text-muted)]">Nog geen thema&apos;s aangemaakt</p>
+                </div>
+            ) : (
+                <div className="neu-flat rounded-2xl overflow-x-auto">
+                    <table className="w-full text-sm text-left">
+                        <thead className="text-xs text-[var(--text-muted)] uppercase bg-[var(--gray-200)]/50 border-b border-[var(--neu-border)]">
+                            <tr>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">Kleur</th>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">Icoon</th>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">Naam</th>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">SDG</th>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">Beschrijving</th>
+                                <th scope="col" className="px-4 md:px-6 py-4 font-bold">Acties</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {themes.map(theme => (
+                                <tr
+                                    key={theme.id}
+                                    data-testid="theme-row"
+                                    className="border-b border-[var(--neu-border)] hover:bg-[var(--gray-200)]/30 transition-colors"
+                                >
+                                    <td className="px-4 md:px-6 py-4">
+                                        <span
+                                            data-testid="theme-swatch"
+                                            className="inline-block w-6 h-6 rounded-full neu-pressed"
+                                            style={{ backgroundColor: theme.color || "transparent" }}
+                                            aria-hidden="true"
+                                        />
+                                    </td>
+                                    <td className="px-4 md:px-6 py-4">
+                                        <span data-testid="theme-icon" className="material-symbols-outlined text-primary" aria-hidden="true">
+                                            {theme.icon || ""}
+                                        </span>
+                                    </td>
+                                    <th scope="row" data-testid="theme-name" className="px-4 md:px-6 py-4 font-bold text-[var(--text-primary)]">
+                                        {theme.name}
+                                    </th>
+                                    <td data-testid="theme-sdg" className="px-4 md:px-6 py-4 text-[var(--text-secondary)]">
+                                        {theme.sdg_code || "—"}
+                                    </td>
+                                    <td
+                                        data-testid="theme-description"
+                                        title={theme.description || ""}
+                                        className="px-4 md:px-6 py-4 text-[var(--text-secondary)] max-w-xs"
+                                    >
+                                        {truncateDescription(theme.description)}
+                                    </td>
+                                    <td className="px-4 md:px-6 py-4">
+                                        <div className="flex items-center gap-2">
+                                            <button type="button" className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5">
+                                                <span className="material-symbols-outlined text-base" aria-hidden="true">edit</span>
+                                                Bewerken
+                                            </button>
+                                            <button type="button" className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5 !text-red-600 hover:!bg-red-50">
+                                                <span className="material-symbols-outlined text-base" aria-hidden="true">delete</span>
+                                                Verwijderen
+                                            </button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -126,11 +126,11 @@ export default function ThemeManagement() {
                                     </td>
                                     <td className="px-4 md:px-6 py-4">
                                         <div className="flex items-center gap-2">
-                                            <button type="button" className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5">
+                                            <button type="button" aria-label={`Bewerken: ${theme.name}`} className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5">
                                                 <span className="material-symbols-outlined text-base" aria-hidden="true">edit</span>
                                                 Bewerken
                                             </button>
-                                            <button type="button" className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5 !text-red-600 hover:!bg-red-50">
+                                            <button type="button" aria-label={`Verwijderen: ${theme.name}`} className="neu-btn !py-2 !px-3 text-sm flex items-center gap-1.5 !text-red-600 hover:!bg-red-50">
                                                 <span className="material-symbols-outlined text-base" aria-hidden="true">delete</span>
                                                 Verwijderen
                                             </button>

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -152,7 +152,6 @@ export default function ThemeManagement() {
             <ThemeCreateModal
                 isOpen={isCreateOpen}
                 onClose={() => setIsCreateOpen(false)}
-                existingThemes={themes}
                 onCreated={theme => {
                     setThemes(prev => sortThemes([...prev, theme]));
                     notification.success("Thema aangemaakt");

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -155,6 +155,7 @@ export default function ThemeManagement() {
                 isOpen={isCreateOpen}
                 onClose={() => setIsCreateOpen(false)}
                 onCreated={theme => {
+                    setError(null);
                     setThemes(prev => sortThemes([...prev, theme]));
                     notification.success("Thema aangemaakt");
                 }}

--- a/projojo_frontend/src/pages/TeacherPage.jsx
+++ b/projojo_frontend/src/pages/TeacherPage.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth/AuthProvider";
 import FormInput from "../components/FormInput";
 import Modal from "../components/Modal";
 import NewSkillsManagement from "../components/NewSkillsManagement";
+import ThemeManagement from "../components/ThemeManagement";
 import PageHeader from '../components/PageHeader';
 import SkeletonList from "../components/SkeletonList";
 import Alert from "../components/Alert";
@@ -250,6 +251,9 @@ export default function TeacherPage() {
 
             <hr className="mt-8 mb-6 border-gray-200" />
             <NewSkillsManagement />
+
+            <hr className="mt-8 mb-6 border-gray-200" />
+            <ThemeManagement />
 
             {/* Archive Confirmation Modal */}
             <Modal

--- a/projojo_frontend/src/services.js
+++ b/projojo_frontend/src/services.js
@@ -268,7 +268,7 @@ export function getProjectThemes(projectId) {
  * @returns {Promise<object>}
  */
 export function createTheme(theme) {
-    return fetchWithError(`${API_BASE_URL}themes`, {
+    return fetchWithError(`${API_BASE_URL}themes/`, {
         method: 'POST',
         body: JSON.stringify(theme)
     });

--- a/tests/e2e/features/ts-task-010-theme-management-list.feature
+++ b/tests/e2e/features/ts-task-010-theme-management-list.feature
@@ -1,0 +1,75 @@
+Feature: TS-task-010 theme management list on the teacher page
+
+  As a docent (teacher)
+  I want to see all themes in a manageable list on my teacher page
+  So that I can oversee the theme catalog and reach the management actions
+
+  # Theme data is stubbed at the network boundary. The shared E2E TypeDB seed
+  # holds no themes and the other theme scenarios mutate the catalog without
+  # cleanup, so a real-stack list assertion here would be order-dependent and
+  # could never produce a loading/error state on demand.
+
+  @ui @theme @TS-task-010
+  Scenario: AC-1 the themes management section is visible on the teacher page
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns the TS-task-010 sample catalog
+    When I open the TeacherPage
+    Then the themes management section should be visible
+
+  @ui @theme @TS-task-010
+  Scenario: AC-2 all themes are listed sorted by display order then name
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns the TS-task-010 sample catalog
+    When I open the TeacherPage
+    Then the theme list should show every sample theme sorted by display order then name
+    And every theme row should show its color swatch, icon, name, SDG code and description
+    And the long theme description should be truncated while keeping the full text accessible
+
+  @ui @theme @TS-task-010
+  Scenario: AC-3 every theme row exposes edit and delete actions
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns the TS-task-010 sample catalog
+    When I open the TeacherPage
+    Then every theme row should have a "Bewerken" and a "Verwijderen" action
+
+  @ui @theme @TS-task-010
+  Scenario: AC-4 a new theme button is available above the list
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns the TS-task-010 sample catalog
+    When I open the TeacherPage
+    Then a "Nieuw thema" button should be visible and clickable
+
+  @ui @theme @TS-task-010
+  Scenario: AC-5 a loading indicator is shown while themes are being fetched
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns the TS-task-010 sample catalog after a delay
+    When I open the TeacherPage
+    Then the theme loading indicator should be visible
+    And the theme list should eventually show every sample theme
+
+  @ui @theme @TS-task-010
+  Scenario: AC-6 an error message is shown when the theme fetch fails
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint fails
+    When I open the TeacherPage
+    Then the theme error message "Er is iets misgegaan bij het ophalen van de thema's." should be visible
+
+  @ui @theme @TS-task-010
+  Scenario: AC-7 an empty state is shown when there are no themes
+    Given I am authenticated in the browser as the TS-task-010 teacher
+    And the themes endpoint returns no themes
+    When I open the TeacherPage
+    Then the theme empty message "Nog geen thema's aangemaakt" should be visible
+    And a "Nieuw thema" button should be visible and clickable
+
+  @ui @theme @TS-task-010
+  Scenario Outline: AC-8 non-teachers are redirected away from the teacher page
+    Given I am authenticated in the browser as the TS-task-010 <role>
+    When I open the TeacherPage
+    Then I should be redirected to the not-found page
+    And the themes management section should not be visible
+
+    Examples:
+      | role       |
+      | student    |
+      | supervisor |

--- a/tests/e2e/features/ts-task-010-theme-management-list.feature
+++ b/tests/e2e/features/ts-task-010-theme-management-list.feature
@@ -4,22 +4,24 @@ Feature: TS-task-010 theme management list on the teacher page
   I want to see all themes in a manageable list on my teacher page
   So that I can oversee the theme catalog and reach the management actions
 
-  # Theme data is stubbed at the network boundary. The shared E2E TypeDB seed
-  # holds no themes and the other theme scenarios mutate the catalog without
-  # cleanup, so a real-stack list assertion here would be order-dependent and
-  # could never produce a loading/error state on demand.
+  # The list/render scenarios (AC-1..AC-4) run against the real backend: they
+  # reset the catalog to a deterministic baseline via the teacher theme API
+  # before asserting, so the shared, mutable catalog can no longer make them
+  # order-dependent. The loading, fetch-error and empty states (AC-5..AC-7)
+  # cannot be produced against a healthy backend, so those remain stubbed at the
+  # network boundary.
 
   @ui @theme @TS-task-010
   Scenario: AC-1 the themes management section is visible on the teacher page
     Given I am authenticated in the browser as the TS-task-010 teacher
-    And the themes endpoint returns the TS-task-010 sample catalog
+    And the theme catalog contains only the TS-010 baseline themes
     When I open the TeacherPage
     Then the themes management section should be visible
 
   @ui @theme @TS-task-010
   Scenario: AC-2 all themes are listed sorted by display order then name
     Given I am authenticated in the browser as the TS-task-010 teacher
-    And the themes endpoint returns the TS-task-010 sample catalog
+    And the theme catalog contains only the TS-010 baseline themes
     When I open the TeacherPage
     Then the theme list should show every sample theme sorted by display order then name
     And every theme row should show its color swatch, icon, name, SDG code and description
@@ -28,14 +30,14 @@ Feature: TS-task-010 theme management list on the teacher page
   @ui @theme @TS-task-010
   Scenario: AC-3 every theme row exposes edit and delete actions
     Given I am authenticated in the browser as the TS-task-010 teacher
-    And the themes endpoint returns the TS-task-010 sample catalog
+    And the theme catalog contains only the TS-010 baseline themes
     When I open the TeacherPage
     Then every theme row should have a "Bewerken" and a "Verwijderen" action
 
   @ui @theme @TS-task-010
   Scenario: AC-4 a new theme button is available above the list
     Given I am authenticated in the browser as the TS-task-010 teacher
-    And the themes endpoint returns the TS-task-010 sample catalog
+    And the theme catalog contains only the TS-010 baseline themes
     When I open the TeacherPage
     Then a "Nieuw thema" button should be visible and clickable
 

--- a/tests/e2e/features/ts-task-010-theme-management-list.feature
+++ b/tests/e2e/features/ts-task-010-theme-management-list.feature
@@ -4,12 +4,13 @@ Feature: TS-task-010 theme management list on the teacher page
   I want to see all themes in a manageable list on my teacher page
   So that I can oversee the theme catalog and reach the management actions
 
-  # The list/render scenarios (AC-1..AC-4) run against the real backend: they
-  # reset the catalog to a deterministic baseline via the teacher theme API
-  # before asserting, so the shared, mutable catalog can no longer make them
-  # order-dependent. The loading, fetch-error and empty states (AC-5..AC-7)
-  # cannot be produced against a healthy backend, so those remain stubbed at the
-  # network boundary.
+  # The list/render scenarios (AC-1..AC-4) and the empty state (AC-7) run against
+  # the real backend: they reset the catalog - to a deterministic baseline, or to
+  # nothing at all - via the teacher theme API before asserting, so the shared,
+  # mutable catalog can no longer make them order-dependent.
+  #
+  # Only the loading indicator (AC-5) and the fetch error (AC-6) remain stubbed at
+  # the network boundary: a healthy backend cannot be made slow or broken on demand.
 
   @ui @theme @TS-task-010
   Scenario: AC-1 the themes management section is visible on the teacher page
@@ -59,7 +60,7 @@ Feature: TS-task-010 theme management list on the teacher page
   @ui @theme @TS-task-010
   Scenario: AC-7 an empty state is shown when there are no themes
     Given I am authenticated in the browser as the TS-task-010 teacher
-    And the themes endpoint returns no themes
+    And the theme catalog is empty
     When I open the TeacherPage
     Then the theme empty message "Nog geen thema's aangemaakt" should be visible
     And a "Nieuw thema" button should be visible and clickable

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -67,13 +67,15 @@ Feature: TS-task-011 theme create modal for teachers
     And a theme row named "Circulaire Economie" should be listed
 
   @ui @theme @TS-task-011
-  Scenario: AC-5 a backend validation error keeps the modal open with an inline message
+  Scenario: AC-5 a blank name is caught client-side and keeps the modal open with an inline message
     Given I am authenticated in the browser as the TS-task-011 teacher
     And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
+    # Whitespace passes the native `required` check but fails the client-side trim guard.
+    And I fill in the theme name "   "
     And I save the new theme
-    Then the inline create error "Naam is verplicht en mag maximaal 100 tekens zijn" should be shown
+    Then the inline create error "Naam is verplicht" should be shown
     And the theme create modal should stay open
 
   @ui @theme @TS-task-011

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -4,17 +4,18 @@ Feature: TS-task-011 theme create modal for teachers
   I want to create new themes via a form on my teacher page
   So that I can expand the theme catalog beyond the initial seed data
 
-  # The isolated E2E seed holds no themes and the sibling theme scenarios mutate
-  # the shared catalog without cleanup, so both the GET /themes/ list and the
-  # POST /themes create call are stubbed at the network boundary. This keeps the
-  # create-modal behaviour deterministic and lets us assert on the exact request
-  # payload the teacher form sends (display_order auto-assignment, comma-joined
-  # SDG codes) as well as on backend error handling.
+  # This suite runs entirely against the real backend. Each scenario first resets
+  # the catalog to a deterministic baseline, so the shared, mutable catalog cannot
+  # make it order-dependent. Nothing is stubbed: the auto-assigned display_order
+  # and the comma-joined SDG code are asserted on what the backend actually
+  # persisted, and the AC-5/AC-6 errors are the real 400s the backend returns for
+  # an empty and a duplicate name. That also exercises the real create request
+  # contract end to end, which a stubbed POST could never prove.
 
   @ui @theme @TS-task-011
   Scenario: AC-1 the create modal opens with empty fields from the Nieuw thema button
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     Then the theme create modal should be visible
@@ -23,7 +24,7 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-2 the create form exposes every required field
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     Then the create form should show a required "Naam" text field
@@ -35,20 +36,18 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-3 the display order is auto-assigned and never shown to the teacher
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will succeed
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     Then the create form should not show a display order field
     When I fill in the theme name "Nieuw Duurzaam Thema"
     And I save the new theme
-    Then the create request display_order should equal the highest sample display order plus one
+    Then the created theme display_order should equal the highest baseline display order plus one
 
   @ui @theme @TS-task-011
   Scenario: AC-4 a valid theme is created, listed and confirmed
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will succeed
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I fill in the theme name "Circulaire Economie"
@@ -60,8 +59,7 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-5 a backend validation error keeps the modal open with an inline message
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will fail with status 400 and message "Naam is verplicht en mag maximaal 100 tekens zijn"
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I save the new theme
@@ -71,8 +69,7 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-6 a duplicate name error is shown inline
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will fail with status 400 and message "Er bestaat al een thema met deze naam"
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I fill in the theme name "Duurzaamheid"
@@ -83,33 +80,31 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-7 cancelling discards the input without creating a theme
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will succeed
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I fill in the theme name "Concept dat verdwijnt"
     And I cancel the theme create modal
     Then the theme create modal should be closed
-    And no theme create request should have been sent
+    And no theme named "Concept dat verdwijnt" should exist
     When I open the theme create modal
     Then all theme create fields should be empty
 
   @ui @theme @TS-task-011
   Scenario: AC-8 selected SDGs are submitted as a comma-separated code
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
-    And the theme create endpoint will succeed
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I fill in the theme name "Water en Voedsel"
     And I select the SDG options "SDG12" and "SDG2"
     And I save the new theme
-    Then the create request sdg_code should equal "SDG2,SDG12"
+    Then the created theme sdg_code should equal "SDG2,SDG12"
 
   @ui @theme @TS-task-011
   Scenario: AC-9 the icon dropdown renders each icon glyph alongside its name
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     And I open the icon dropdown
@@ -118,7 +113,7 @@ Feature: TS-task-011 theme create modal for teachers
   @ui @theme @TS-task-011
   Scenario: AC-10 the color picker uses a native color input and displays the chosen hex
     Given I am authenticated in the browser as the TS-task-011 teacher
-    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
     Then the color field should be a native color input

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -45,6 +45,16 @@ Feature: TS-task-011 theme create modal for teachers
     Then the created theme display_order should equal the highest baseline display order plus one
 
   @ui @theme @TS-task-011
+  Scenario: AC-3 the first theme in an empty catalog gets display order one
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the theme catalog is empty
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I fill in the theme name "Eerste Thema"
+    And I save the new theme
+    Then the created theme display_order should equal 1
+
+  @ui @theme @TS-task-011
   Scenario: AC-4 a valid theme is created, listed and confirmed
     Given I am authenticated in the browser as the TS-task-011 teacher
     And the theme catalog contains only the TS-011 baseline themes

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -102,7 +102,7 @@ Feature: TS-task-011 theme create modal for teachers
     When I open the TeacherPage
     And I open the theme create modal
     And I fill in the theme name "Water en Voedsel"
-    And I select the SDG options "SDG2" and "SDG12"
+    And I select the SDG options "SDG12" and "SDG2"
     And I save the new theme
     Then the create request sdg_code should equal "SDG2,SDG12"
 

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -1,0 +1,126 @@
+Feature: TS-task-011 theme create modal for teachers
+
+  As a docent (teacher)
+  I want to create new themes via a form on my teacher page
+  So that I can expand the theme catalog beyond the initial seed data
+
+  # The isolated E2E seed holds no themes and the sibling theme scenarios mutate
+  # the shared catalog without cleanup, so both the GET /themes/ list and the
+  # POST /themes create call are stubbed at the network boundary. This keeps the
+  # create-modal behaviour deterministic and lets us assert on the exact request
+  # payload the teacher form sends (display_order auto-assignment, comma-joined
+  # SDG codes) as well as on backend error handling.
+
+  @ui @theme @TS-task-011
+  Scenario: AC-1 the create modal opens with empty fields from the Nieuw thema button
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    When I open the TeacherPage
+    And I open the theme create modal
+    Then the theme create modal should be visible
+    And all theme create fields should be empty
+
+  @ui @theme @TS-task-011
+  Scenario: AC-2 the create form exposes every required field
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    When I open the TeacherPage
+    And I open the theme create modal
+    Then the create form should show a required "Naam" text field
+    And the create form should show a "Beschrijving" textarea with a "0/500" character counter
+    And the create form should offer SDG1 through SDG17 as labelled multi-select options
+    And the create form should offer an icon dropdown of at least 80 predefined icons
+    And the create form should show a native color picker with its hex value
+
+  @ui @theme @TS-task-011
+  Scenario: AC-3 the display order is auto-assigned and never shown to the teacher
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will succeed
+    When I open the TeacherPage
+    And I open the theme create modal
+    Then the create form should not show a display order field
+    When I fill in the theme name "Nieuw Duurzaam Thema"
+    And I save the new theme
+    Then the create request display_order should equal the highest sample display order plus one
+
+  @ui @theme @TS-task-011
+  Scenario: AC-4 a valid theme is created, listed and confirmed
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will succeed
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I fill in the theme name "Circulaire Economie"
+    And I save the new theme
+    Then the theme create modal should be closed
+    And a "Thema aangemaakt" success message should be shown
+    And a theme row named "Circulaire Economie" should be listed
+
+  @ui @theme @TS-task-011
+  Scenario: AC-5 a backend validation error keeps the modal open with an inline message
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will fail with status 400 and message "Naam is verplicht en mag maximaal 100 tekens zijn"
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I save the new theme
+    Then the theme create modal should stay open
+    And the inline create error "Naam is verplicht en mag maximaal 100 tekens zijn" should be shown
+
+  @ui @theme @TS-task-011
+  Scenario: AC-6 a duplicate name error is shown inline
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will fail with status 400 and message "Er bestaat al een thema met deze naam"
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I fill in the theme name "Duurzaamheid"
+    And I save the new theme
+    Then the theme create modal should stay open
+    And the inline create error "Er bestaat al een thema met deze naam" should be shown
+
+  @ui @theme @TS-task-011
+  Scenario: AC-7 cancelling discards the input without creating a theme
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will succeed
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I fill in the theme name "Concept dat verdwijnt"
+    And I cancel the theme create modal
+    Then the theme create modal should be closed
+    And no theme create request should have been sent
+    When I open the theme create modal
+    Then all theme create fields should be empty
+
+  @ui @theme @TS-task-011
+  Scenario: AC-8 selected SDGs are submitted as a comma-separated code
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    And the theme create endpoint will succeed
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I fill in the theme name "Water en Voedsel"
+    And I select the SDG options "SDG2" and "SDG12"
+    And I save the new theme
+    Then the create request sdg_code should equal "SDG2,SDG12"
+
+  @ui @theme @TS-task-011
+  Scenario: AC-9 the icon dropdown renders each icon glyph alongside its name
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I open the icon dropdown
+    Then every icon option should render its Material Symbols glyph next to its name
+
+  @ui @theme @TS-task-011
+  Scenario: AC-10 the color picker uses a native color input and displays the chosen hex
+    Given I am authenticated in the browser as the TS-task-011 teacher
+    And the themes endpoint returns the TS-task-011 sample catalog
+    When I open the TeacherPage
+    And I open the theme create modal
+    Then the color field should be a native color input
+    When I pick the color "#123456"
+    Then the color hex value "#123456" should be displayed next to the picker

--- a/tests/e2e/features/ts-task-011-theme-create-modal.feature
+++ b/tests/e2e/features/ts-task-011-theme-create-modal.feature
@@ -73,8 +73,8 @@ Feature: TS-task-011 theme create modal for teachers
     When I open the TeacherPage
     And I open the theme create modal
     And I save the new theme
-    Then the theme create modal should stay open
-    And the inline create error "Naam is verplicht en mag maximaal 100 tekens zijn" should be shown
+    Then the inline create error "Naam is verplicht en mag maximaal 100 tekens zijn" should be shown
+    And the theme create modal should stay open
 
   @ui @theme @TS-task-011
   Scenario: AC-6 a duplicate name error is shown inline
@@ -82,10 +82,10 @@ Feature: TS-task-011 theme create modal for teachers
     And the theme catalog contains only the TS-011 baseline themes
     When I open the TeacherPage
     And I open the theme create modal
-    And I fill in the theme name "Duurzaamheid"
+    And I fill in the theme name of an existing theme
     And I save the new theme
-    Then the theme create modal should stay open
-    And the inline create error "Er bestaat al een thema met deze naam" should be shown
+    Then the inline create error "Er bestaat al een thema met deze naam" should be shown
+    And the theme create modal should stay open
 
   @ui @theme @TS-task-011
   Scenario: AC-7 cancelling discards the input without creating a theme

--- a/tests/e2e/steps/teacher-page.shared.steps.cjs
+++ b/tests/e2e/steps/teacher-page.shared.steps.cjs
@@ -1,0 +1,13 @@
+// Shared teacher-page steps reused across the theme management suites
+// (TS-task-010 list, TS-task-011 create modal, and the sibling theme tasks).
+
+const { When } = require('@qavajs/core');
+
+const { FRONTEND_URL } = require('../support/test-data.cjs');
+const { page } = require('../support/e2e-session.cjs');
+
+const TEACHER_PAGE_URL = `${FRONTEND_URL}/teacher`;
+
+When('I open the TeacherPage', async function () {
+  await page(this).goto(TEACHER_PAGE_URL);
+});

--- a/tests/e2e/steps/theme-catalog.shared.steps.cjs
+++ b/tests/e2e/steps/theme-catalog.shared.steps.cjs
@@ -1,0 +1,15 @@
+// Theme catalog steps shared across the theme management suites (TS-task-010
+// list, TS-task-011 create modal, and the sibling theme tasks).
+
+const { Given } = require('@qavajs/core');
+
+const { resetThemeCatalog } = require('../support/theme-catalog.cjs');
+
+Given('the theme catalog is empty', async function () {
+  // A genuinely empty catalog: the reset wipes every theme and creates none.
+  // Used by the TS-010 empty state (proving the real GET /themes/ response
+  // rather than a stubbed one) and by the TS-011 first-theme scenario (which
+  // exercises the empty-catalog edge of the server's display_order assignment,
+  // max of nothing + 1 = 1).
+  await resetThemeCatalog([]);
+});

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -9,6 +9,12 @@ const {
 } = require('../support/test-data.cjs');
 const { stubThemesEndpoint } = require('../support/theme-stub.cjs');
 const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
+const {
+  THEME_SEED_BASELINE,
+  EXPECTED_SORTED_NAMES,
+  LONG_DESCRIPTION,
+  resetThemeCatalog,
+} = require('../support/theme-catalog.cjs');
 
 const THEME_ERROR_MESSAGE = "Er is iets misgegaan bij het ophalen van de thema's.";
 
@@ -18,32 +24,16 @@ const ROLE_USER_IDS = {
   supervisor: PROOF_SUPERVISOR_USER_ID,
 };
 
-// Deliberately supplied to the stub in an unsorted order, with a display_order
-// tie (3) whose names are NOT alphabetical, so AC-2 truly proves the list is
-// rendered sorted by display_order then name rather than in received order.
-const LONG_DESCRIPTION =
-  'Dit is een opzettelijk zeer lange themabeschrijving die ruim voorbij de afkapgrens loopt zodat de weergave de tekst zichtbaar moet inkorten in de lijst.';
+// The deterministic baseline catalog, its expected sorted order, and the long
+// description live in the shared theme-catalog helper, so the real-backend reset
+// (AC-1..AC-4) and the stub-based states (AC-5..AC-7) assert against one source
+// of truth. Aliased locally to keep the assertion steps below unchanged.
+const SAMPLE_THEMES = THEME_SEED_BASELINE;
 
-const SAMPLE_THEMES = [
-  { id: 'ts010-onderwijs', name: 'Onderwijs', sdg_code: 'SDG4', icon: 'school', color: '#E91E63', display_order: 6, description: 'Educatie en kennisoverdracht.' },
-  { id: 'ts010-bravo', name: 'Bravo Thema', sdg_code: 'SDG9', icon: 'lightbulb', color: '#9C27B0', display_order: 3, description: 'Beschrijving bravo.' },
-  { id: 'ts010-duurzaamheid', name: 'Duurzaamheid', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Duurzame praktijken.' },
-  { id: 'ts010-water', name: 'Water', sdg_code: 'SDG14', icon: 'water_drop', color: '#00BCD4', display_order: 5, description: 'Waterbeheer en biodiversiteit.' },
-  { id: 'ts010-alpha', name: 'Alpha Thema', sdg_code: 'SDG2', icon: 'restaurant', color: '#FF9800', display_order: 3, description: 'Beschrijving alpha.' },
-  { id: 'ts010-klimaat', name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: LONG_DESCRIPTION },
-];
-
-// Expected teacher-visible order: display_order ascending, then name. Alpha
-// Thema precedes Bravo Thema at the shared display_order 3. Hardcoded on purpose
-// so the assertion does not mirror the component's own comparator.
-const EXPECTED_SORTED_NAMES = [
-  'Duurzaamheid',
-  'Klimaat & Milieu',
-  'Alpha Thema',
-  'Bravo Thema',
-  'Water',
-  'Onderwijs',
-];
+// Loading/error/empty states cannot be produced against a healthy backend, so
+// those scenarios still stub GET /themes/. The stub body needs stable ids for
+// React keys; the real-backend scenarios receive ids from the backend on create.
+const STUB_CATALOG = SAMPLE_THEMES.map((theme, index) => ({ id: `ts010-stub-${index}`, ...theme }));
 
 function hexToRgb(hex) {
   const value = hex.replace('#', '');
@@ -69,12 +59,15 @@ Given('I am authenticated in the browser as the TS-task-010 {word}', async funct
   await authenticateInBrowser(this, userId);
 });
 
-Given('the themes endpoint returns the TS-task-010 sample catalog', async function () {
-  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES });
+Given('the theme catalog contains only the TS-010 baseline themes', async function () {
+  // Real backend: wipe the live catalog and recreate the deterministic baseline
+  // via the teacher-authenticated theme API, so the list assertions run against
+  // the real GET /themes/ response rather than a stubbed one.
+  await resetThemeCatalog();
 });
 
 Given('the themes endpoint returns the TS-task-010 sample catalog after a delay', async function () {
-  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES, delayMs: 2000 });
+  await stubThemesEndpoint(page(this), { status: 200, body: STUB_CATALOG, delayMs: 2000 });
 });
 
 Given('the themes endpoint returns no themes', async function () {

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -70,10 +70,6 @@ Given('the themes endpoint returns the TS-task-010 sample catalog after a delay'
   await stubThemesEndpoint(page(this), { status: 200, body: STUB_CATALOG, delayMs: 2000 });
 });
 
-Given('the themes endpoint returns no themes', async function () {
-  await stubThemesEndpoint(page(this), { status: 200, body: [] });
-});
-
 Given('the themes endpoint fails', async function () {
   await stubThemesEndpoint(page(this), { status: 500, body: { detail: 'boom' } });
 });

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -36,10 +36,17 @@ const SAMPLE_THEMES = [
   { id: 'ts010-klimaat', name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: LONG_DESCRIPTION },
 ];
 
-// Same comparator the component must apply: display_order asc, then name.
-const EXPECTED_SORTED_NAMES = [...SAMPLE_THEMES]
-  .sort((a, b) => (a.display_order ?? 999) - (b.display_order ?? 999) || a.name.localeCompare(b.name))
-  .map((theme) => theme.name);
+// Expected teacher-visible order: display_order ascending, then name. Alpha
+// Thema precedes Bravo Thema at the shared display_order 3. Hardcoded on purpose
+// so the assertion does not mirror the component's own comparator.
+const EXPECTED_SORTED_NAMES = [
+  'Duurzaamheid',
+  'Klimaat & Milieu',
+  'Alpha Thema',
+  'Bravo Thema',
+  'Water',
+  'Onderwijs',
+];
 
 function page(world) {
   const current = world?.playwright?.page;
@@ -183,8 +190,18 @@ Then('every theme row should have a {string} and a {string} action', async funct
 
   for (const row of rows) {
     const name = (await row.getByTestId('theme-name').innerText()).trim();
-    assert.equal(await row.getByRole('button', { name: editLabel }).count(), 1, `Expected a '${editLabel}' action on row '${name}'`);
-    assert.equal(await row.getByRole('button', { name: deleteLabel }).count(), 1, `Expected a '${deleteLabel}' action on row '${name}'`);
+    // Require the per-row accessible name so a screen reader user knows which
+    // theme each action belongs to (exact match, not a substring).
+    assert.equal(
+      await row.getByRole('button', { name: `${editLabel}: ${name}`, exact: true }).count(),
+      1,
+      `Expected a '${editLabel}' action labelled for row '${name}'`,
+    );
+    assert.equal(
+      await row.getByRole('button', { name: `${deleteLabel}: ${name}`, exact: true }).count(),
+      1,
+      `Expected a '${deleteLabel}' action labelled for row '${name}'`,
+    );
   }
 });
 

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -1,17 +1,14 @@
 const assert = require('node:assert/strict');
 
-const { Given, Then, When } = require('@qavajs/core');
+const { Given, Then } = require('@qavajs/core');
 
 const {
-  BACKEND_URL,
-  FRONTEND_URL,
   E2E_TEACHER_ID,
   E2E_STUDENT_ID,
   PROOF_SUPERVISOR_USER_ID,
 } = require('../support/test-data.cjs');
 const { stubThemesEndpoint } = require('../support/theme-stub.cjs');
-
-const TEACHER_PAGE_URL = `${FRONTEND_URL}/teacher`;
+const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
 
 const THEME_ERROR_MESSAGE = "Er is iets misgegaan bij het ophalen van de thema's.";
 
@@ -48,37 +45,12 @@ const EXPECTED_SORTED_NAMES = [
   'Onderwijs',
 ];
 
-function page(world) {
-  const current = world?.playwright?.page;
-  assert.ok(current, 'Expected the qavajs world to expose playwright.page');
-  return current;
-}
-
 function hexToRgb(hex) {
   const value = hex.replace('#', '');
   const r = parseInt(value.slice(0, 2), 16);
   const g = parseInt(value.slice(2, 4), 16);
   const b = parseInt(value.slice(4, 6), 16);
   return `rgb(${r}, ${g}, ${b})`;
-}
-
-async function loginToken(userId) {
-  const response = await fetch(`${BACKEND_URL}/auth/test/login/${userId}`, {
-    method: 'POST',
-    headers: { Accept: 'application/json' },
-  });
-  assert.equal(response.status, 200, `Expected test login for ${userId} to return 200, received ${response.status}`);
-  const payload = await response.json();
-  assert.ok(payload?.access_token, `Expected test login for ${userId} to return an access_token`);
-  return payload.access_token;
-}
-
-async function authenticateInBrowser(world, role) {
-  const userId = ROLE_USER_IDS[role];
-  assert.ok(userId, `Unknown TS-task-010 role '${role}'`);
-  const token = await loginToken(userId);
-  await page(world).goto(FRONTEND_URL);
-  await page(world).evaluate((authToken) => localStorage.setItem('token', authToken), token);
 }
 
 async function readThemeRowsByName(world) {
@@ -92,7 +64,9 @@ async function readThemeRowsByName(world) {
 }
 
 Given('I am authenticated in the browser as the TS-task-010 {word}', async function (role) {
-  await authenticateInBrowser(this, role);
+  const userId = ROLE_USER_IDS[role];
+  assert.ok(userId, `Unknown TS-task-010 role '${role}'`);
+  await authenticateInBrowser(this, userId);
 });
 
 Given('the themes endpoint returns the TS-task-010 sample catalog', async function () {
@@ -109,10 +83,6 @@ Given('the themes endpoint returns no themes', async function () {
 
 Given('the themes endpoint fails', async function () {
   await stubThemesEndpoint(page(this), { status: 500, body: { detail: 'boom' } });
-});
-
-When('I open the TeacherPage', async function () {
-  await page(this).goto(TEACHER_PAGE_URL);
 });
 
 Then('the themes management section should be visible', async function () {

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -1,0 +1,232 @@
+const assert = require('node:assert/strict');
+
+const { Given, Then, When } = require('@qavajs/core');
+
+const {
+  BACKEND_URL,
+  FRONTEND_URL,
+  E2E_TEACHER_ID,
+  E2E_STUDENT_ID,
+  PROOF_SUPERVISOR_USER_ID,
+} = require('../support/test-data.cjs');
+const { stubThemesEndpoint } = require('../support/theme-stub.cjs');
+
+const TEACHER_PAGE_URL = `${FRONTEND_URL}/teacher`;
+
+const THEME_ERROR_MESSAGE = "Er is iets misgegaan bij het ophalen van de thema's.";
+
+const ROLE_USER_IDS = {
+  teacher: E2E_TEACHER_ID,
+  student: E2E_STUDENT_ID,
+  supervisor: PROOF_SUPERVISOR_USER_ID,
+};
+
+// Deliberately supplied to the stub in an unsorted order, with a display_order
+// tie (3) whose names are NOT alphabetical, so AC-2 truly proves the list is
+// rendered sorted by display_order then name rather than in received order.
+const LONG_DESCRIPTION =
+  'Dit is een opzettelijk zeer lange themabeschrijving die ruim voorbij de afkapgrens loopt zodat de weergave de tekst zichtbaar moet inkorten in de lijst.';
+
+const SAMPLE_THEMES = [
+  { id: 'ts010-onderwijs', name: 'Onderwijs', sdg_code: 'SDG4', icon: 'school', color: '#E91E63', display_order: 6, description: 'Educatie en kennisoverdracht.' },
+  { id: 'ts010-bravo', name: 'Bravo Thema', sdg_code: 'SDG9', icon: 'lightbulb', color: '#9C27B0', display_order: 3, description: 'Beschrijving bravo.' },
+  { id: 'ts010-duurzaamheid', name: 'Duurzaamheid', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Duurzame praktijken.' },
+  { id: 'ts010-water', name: 'Water', sdg_code: 'SDG14', icon: 'water_drop', color: '#00BCD4', display_order: 5, description: 'Waterbeheer en biodiversiteit.' },
+  { id: 'ts010-alpha', name: 'Alpha Thema', sdg_code: 'SDG2', icon: 'restaurant', color: '#FF9800', display_order: 3, description: 'Beschrijving alpha.' },
+  { id: 'ts010-klimaat', name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: LONG_DESCRIPTION },
+];
+
+// Same comparator the component must apply: display_order asc, then name.
+const EXPECTED_SORTED_NAMES = [...SAMPLE_THEMES]
+  .sort((a, b) => (a.display_order ?? 999) - (b.display_order ?? 999) || a.name.localeCompare(b.name))
+  .map((theme) => theme.name);
+
+function page(world) {
+  const current = world?.playwright?.page;
+  assert.ok(current, 'Expected the qavajs world to expose playwright.page');
+  return current;
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace('#', '');
+  const r = parseInt(value.slice(0, 2), 16);
+  const g = parseInt(value.slice(2, 4), 16);
+  const b = parseInt(value.slice(4, 6), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+async function loginToken(userId) {
+  const response = await fetch(`${BACKEND_URL}/auth/test/login/${userId}`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  });
+  assert.equal(response.status, 200, `Expected test login for ${userId} to return 200, received ${response.status}`);
+  const payload = await response.json();
+  assert.ok(payload?.access_token, `Expected test login for ${userId} to return an access_token`);
+  return payload.access_token;
+}
+
+async function authenticateInBrowser(world, role) {
+  const userId = ROLE_USER_IDS[role];
+  assert.ok(userId, `Unknown TS-task-010 role '${role}'`);
+  const token = await loginToken(userId);
+  await page(world).goto(FRONTEND_URL);
+  await page(world).evaluate((authToken) => localStorage.setItem('token', authToken), token);
+}
+
+async function readThemeRowsByName(world) {
+  const rows = await page(world).getByTestId('theme-row').all();
+  const byName = {};
+  for (const row of rows) {
+    const name = (await row.getByTestId('theme-name').innerText()).trim();
+    byName[name] = row;
+  }
+  return { rows, byName };
+}
+
+Given('I am authenticated in the browser as the TS-task-010 {word}', async function (role) {
+  await authenticateInBrowser(this, role);
+});
+
+Given('the themes endpoint returns the TS-task-010 sample catalog', async function () {
+  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES });
+});
+
+Given('the themes endpoint returns the TS-task-010 sample catalog after a delay', async function () {
+  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES, delayMs: 2000 });
+});
+
+Given('the themes endpoint returns no themes', async function () {
+  await stubThemesEndpoint(page(this), { status: 200, body: [] });
+});
+
+Given('the themes endpoint fails', async function () {
+  await stubThemesEndpoint(page(this), { status: 500, body: { detail: 'boom' } });
+});
+
+When('I open the TeacherPage', async function () {
+  await page(this).goto(TEACHER_PAGE_URL);
+});
+
+Then('the themes management section should be visible', async function () {
+  const section = page(this).getByTestId('theme-management');
+  await section.waitFor({ state: 'visible' });
+  assert.equal(await section.isVisible(), true, 'Expected the themes management section to be visible');
+  await assert.doesNotReject(
+    page(this).getByRole('heading', { name: "Thema's" }).waitFor({ state: 'visible' }),
+    'Expected a "Thema\'s" heading in the themes section',
+  );
+});
+
+Then('the themes management section should not be visible', async function () {
+  const section = page(this).getByTestId('theme-management');
+  // After the redirect React unmounts TeacherPage (and its theme section); wait
+  // for that to settle rather than sampling the DOM mid-transition.
+  await section.waitFor({ state: 'detached', timeout: 10_000 });
+  assert.equal(
+    await section.count(),
+    0,
+    'Expected no themes management section to be rendered',
+  );
+});
+
+Then('the theme list should show every sample theme sorted by display order then name', async function () {
+  await page(this).getByTestId('theme-row').first().waitFor({ state: 'visible' });
+  const renderedNames = (await page(this).getByTestId('theme-name').allInnerTexts()).map((name) => name.trim());
+  assert.deepEqual(
+    renderedNames,
+    EXPECTED_SORTED_NAMES,
+    `Expected themes rendered sorted by display_order then name.\n  expected: ${JSON.stringify(EXPECTED_SORTED_NAMES)}\n  actual:   ${JSON.stringify(renderedNames)}`,
+  );
+});
+
+Then('every theme row should show its color swatch, icon, name, SDG code and description', async function () {
+  await page(this).getByTestId('theme-row').first().waitFor({ state: 'visible' });
+  const { rows, byName } = await readThemeRowsByName(this);
+  assert.equal(rows.length, SAMPLE_THEMES.length, `Expected ${SAMPLE_THEMES.length} theme rows, found ${rows.length}`);
+
+  for (const theme of SAMPLE_THEMES) {
+    const row = byName[theme.name];
+    assert.ok(row, `Expected a rendered row for theme '${theme.name}'`);
+
+    const swatch = row.getByTestId('theme-swatch');
+    assert.equal(await swatch.isVisible(), true, `Expected a color swatch for '${theme.name}'`);
+    const backgroundColor = await swatch.evaluate((el) => getComputedStyle(el).backgroundColor);
+    assert.equal(backgroundColor, hexToRgb(theme.color), `Expected swatch for '${theme.name}' to use color ${theme.color}`);
+
+    assert.equal((await row.getByTestId('theme-icon').innerText()).trim(), theme.icon, `Expected icon '${theme.icon}' for '${theme.name}'`);
+    assert.equal((await row.getByTestId('theme-sdg').innerText()).trim(), theme.sdg_code, `Expected SDG '${theme.sdg_code}' for '${theme.name}'`);
+
+    const description = (await row.getByTestId('theme-description').innerText()).trim();
+    assert.ok(description.length > 0, `Expected a visible description for '${theme.name}'`);
+  }
+});
+
+Then('the long theme description should be truncated while keeping the full text accessible', async function () {
+  const { byName } = await readThemeRowsByName(this);
+  const row = byName['Klimaat & Milieu'];
+  assert.ok(row, 'Expected the long-description theme row to be rendered');
+
+  const cell = row.getByTestId('theme-description');
+  const shown = (await cell.innerText()).trim();
+  const fullText = await cell.getAttribute('title');
+
+  assert.equal(fullText, LONG_DESCRIPTION, 'Expected the full description to remain available via the title attribute');
+  assert.ok(shown.length < LONG_DESCRIPTION.length, `Expected the shown description (${shown.length}) to be shorter than the full text (${LONG_DESCRIPTION.length})`);
+  assert.ok(shown.endsWith('…'), `Expected the truncated description to end with an ellipsis, got '${shown}'`);
+});
+
+Then('every theme row should have a {string} and a {string} action', async function (editLabel, deleteLabel) {
+  await page(this).getByTestId('theme-row').first().waitFor({ state: 'visible' });
+  const rows = await page(this).getByTestId('theme-row').all();
+  assert.equal(rows.length, SAMPLE_THEMES.length, `Expected ${SAMPLE_THEMES.length} theme rows, found ${rows.length}`);
+
+  for (const row of rows) {
+    const name = (await row.getByTestId('theme-name').innerText()).trim();
+    assert.equal(await row.getByRole('button', { name: editLabel }).count(), 1, `Expected a '${editLabel}' action on row '${name}'`);
+    assert.equal(await row.getByRole('button', { name: deleteLabel }).count(), 1, `Expected a '${deleteLabel}' action on row '${name}'`);
+  }
+});
+
+Then('a {string} button should be visible and clickable', async function (label) {
+  const button = page(this).getByRole('button', { name: label });
+  await button.waitFor({ state: 'visible' });
+  assert.equal(await button.isVisible(), true, `Expected the '${label}' button to be visible`);
+  assert.equal(await button.isEnabled(), true, `Expected the '${label}' button to be enabled`);
+  // Proves it is actually clickable (no overlay/disabled state); the create flow
+  // itself is TS-task-011, so we only require the action to be reachable here.
+  await button.click();
+});
+
+Then('the theme loading indicator should be visible', async function () {
+  const loading = page(this).getByTestId('theme-loading');
+  await loading.waitFor({ state: 'visible' });
+  assert.equal(await loading.isVisible(), true, 'Expected a loading indicator while themes are being fetched');
+});
+
+Then('the theme list should eventually show every sample theme', async function () {
+  await page(this).getByTestId('theme-row').first().waitFor({ state: 'visible', timeout: 15_000 });
+  const renderedNames = (await page(this).getByTestId('theme-name').allInnerTexts()).map((name) => name.trim());
+  assert.equal(renderedNames.length, SAMPLE_THEMES.length, `Expected ${SAMPLE_THEMES.length} themes after loading, found ${renderedNames.length}`);
+  assert.equal(await page(this).getByTestId('theme-loading').count(), 0, 'Expected the loading indicator to disappear once themes are loaded');
+});
+
+Then('the theme error message {string} should be visible', async function (message) {
+  assert.equal(message, THEME_ERROR_MESSAGE, 'Scenario error message does not match the specified copy');
+  const errorText = page(this).getByText(message, { exact: false });
+  await errorText.waitFor({ state: 'visible' });
+  assert.equal(await errorText.isVisible(), true, `Expected the error message '${message}' to be visible`);
+  assert.equal(await page(this).getByTestId('theme-row').count(), 0, 'Expected no theme rows to be rendered in the error state');
+});
+
+Then('the theme empty message {string} should be visible', async function (message) {
+  const empty = page(this).getByTestId('theme-empty');
+  await empty.waitFor({ state: 'visible' });
+  assert.ok((await empty.innerText()).includes(message), `Expected the empty state to show '${message}'`);
+  assert.equal(await page(this).getByTestId('theme-row').count(), 0, 'Expected no theme rows in the empty state');
+});
+
+Then('I should be redirected to the not-found page', async function () {
+  await page(this).waitForURL('**/not-found', { timeout: 15_000 });
+  assert.ok(page(this).url().endsWith('/not-found'), `Expected to land on /not-found, current URL is ${page(this).url()}`);
+});

--- a/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
+++ b/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
@@ -1,0 +1,277 @@
+const assert = require('node:assert/strict');
+
+const { Given, Then, When } = require('@qavajs/core');
+
+const { E2E_TEACHER_ID } = require('../support/test-data.cjs');
+const { stubThemesEndpoint, stubCreateThemeEndpoint } = require('../support/theme-stub.cjs');
+const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
+
+// Sample catalog served for GET /themes/. Display orders are deliberately not
+// contiguous and their max (6) is on a theme whose name is not last
+// alphabetically, so "max display order + 1" (AC-3) is an unambiguous target.
+const SAMPLE_THEMES = [
+  { id: 'ts011-duurzaamheid', name: 'Duurzaamheid', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Duurzame praktijken.' },
+  { id: 'ts011-klimaat', name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: 'Klimaat en milieu.' },
+  { id: 'ts011-innovatie', name: 'Innovatie', sdg_code: 'SDG9', icon: 'lightbulb', color: '#9C27B0', display_order: 6, description: 'Innovatie en technologie.' },
+];
+
+const MAX_SAMPLE_DISPLAY_ORDER = Math.max(...SAMPLE_THEMES.map((theme) => theme.display_order));
+
+// Canonical Dutch SDG labels (issue example "SDG1 — Geen armoede" +
+// THEME_SDG_IMPLEMENTATION_PLAN.md §3.1). Hardcoded here on purpose so the
+// assertion proves the component renders the right copy rather than mirroring
+// the component's own constant.
+const SDG_LABELS = {
+  SDG1: 'Geen armoede',
+  SDG2: 'Geen honger',
+  SDG3: 'Goede gezondheid en welzijn',
+  SDG4: 'Kwaliteitsonderwijs',
+  SDG5: 'Gendergelijkheid',
+  SDG6: 'Schoon water en sanitair',
+  SDG7: 'Betaalbare en duurzame energie',
+  SDG8: 'Waardig werk en economische groei',
+  SDG9: 'Industrie, innovatie en infrastructuur',
+  SDG10: 'Ongelijkheid verminderen',
+  SDG11: 'Duurzame steden en gemeenschappen',
+  SDG12: 'Verantwoorde consumptie en productie',
+  SDG13: 'Klimaatactie',
+  SDG14: 'Leven in het water',
+  SDG15: 'Leven op het land',
+  SDG16: 'Vrede, justitie en sterke instellingen',
+  SDG17: 'Partnerschap om doelstellingen te bereiken',
+};
+
+function createModal(world) {
+  return page(world).getByTestId('theme-create-modal');
+}
+
+Given('I am authenticated in the browser as the TS-task-011 teacher', async function () {
+  await authenticateInBrowser(this, E2E_TEACHER_ID);
+});
+
+Given('the themes endpoint returns the TS-task-011 sample catalog', async function () {
+  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES });
+});
+
+Given('the theme create endpoint will succeed', async function () {
+  this.createRequests = await stubCreateThemeEndpoint(page(this), { status: 201 });
+});
+
+Given('the theme create endpoint will fail with status {int} and message {string}', async function (status, message) {
+  this.createRequests = await stubCreateThemeEndpoint(page(this), { status, detail: message });
+});
+
+When('I open the theme create modal', async function () {
+  await page(this).getByRole('button', { name: 'Nieuw thema' }).click();
+  await createModal(this).waitFor({ state: 'visible' });
+});
+
+When('I fill in the theme name {string}', async function (name) {
+  await createModal(this).getByTestId('theme-name-input').fill(name);
+});
+
+When('I save the new theme', async function () {
+  await createModal(this).getByTestId('theme-save-button').click();
+});
+
+When('I cancel the theme create modal', async function () {
+  await createModal(this).getByTestId('theme-cancel-button').click();
+});
+
+When('I select the SDG options {string} and {string}', async function (firstCode, secondCode) {
+  const modal = createModal(this);
+  await modal.getByTestId('theme-sdg-trigger').click();
+  for (const code of [firstCode, secondCode]) {
+    await modal.getByTestId(`theme-sdg-checkbox-${code}`).check();
+  }
+});
+
+When('I open the icon dropdown', async function () {
+  await createModal(this).getByTestId('theme-icon-trigger').click();
+});
+
+When('I pick the color {string}', async function (hex) {
+  // <input type="color"> is not fillable, and a controlled React input ignores a
+  // direct value assignment. Use the native value setter so React's change
+  // tracker fires onChange, mirroring a user picking a swatch.
+  const input = createModal(this).getByTestId('theme-color-input');
+  await input.evaluate((element, value) => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    setter.call(element, value);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }, hex);
+});
+
+Then('the theme create modal should be visible', async function () {
+  assert.equal(await createModal(this).isVisible(), true, 'Expected the theme create modal to be visible');
+});
+
+Then('all theme create fields should be empty', async function () {
+  const modal = createModal(this);
+  assert.equal(await modal.getByTestId('theme-name-input').inputValue(), '', 'Expected the name field to be empty');
+  assert.equal(await modal.getByTestId('theme-description-input').inputValue(), '', 'Expected the description field to be empty');
+
+  const sdgTrigger = (await modal.getByTestId('theme-sdg-trigger').innerText()).trim();
+  assert.ok(/geen|selecteer/i.test(sdgTrigger), `Expected the SDG selector to show its empty placeholder, got '${sdgTrigger}'`);
+
+  const iconTrigger = (await modal.getByTestId('theme-icon-trigger').innerText()).trim();
+  assert.ok(/selecteer/i.test(iconTrigger), `Expected the icon selector to show its empty placeholder, got '${iconTrigger}'`);
+});
+
+Then('the create form should show a required {string} text field', async function (label) {
+  const modal = createModal(this);
+  const input = modal.getByTestId('theme-name-input');
+  await input.waitFor({ state: 'visible' });
+  assert.equal(await input.getAttribute('type'), 'text', `Expected the '${label}' field to be a text input`);
+  assert.equal(await input.getAttribute('required'), '', `Expected the '${label}' field to be marked required`);
+  // The label must carry a visible required marker (*) next to the field name.
+  const requiredLabel = modal.locator('label', { hasText: label }).filter({ hasText: '*' });
+  assert.equal(await requiredLabel.count() >= 1, true, `Expected a '${label}' label with a required '*' marker`);
+});
+
+Then('the create form should show a {string} textarea with a {string} character counter', async function (label, counter) {
+  const modal = createModal(this);
+  const textarea = modal.getByTestId('theme-description-input');
+  await textarea.waitFor({ state: 'visible' });
+  assert.equal(
+    await textarea.evaluate((element) => element.tagName.toLowerCase()),
+    'textarea',
+    `Expected the '${label}' field to be a textarea`,
+  );
+  const counterText = (await modal.getByTestId('theme-description-counter').innerText()).replace(/\s+/g, '');
+  assert.ok(counterText.includes(counter), `Expected the description counter to show '${counter}', got '${counterText}'`);
+});
+
+Then('the create form should offer SDG1 through SDG17 as labelled multi-select options', async function () {
+  const modal = createModal(this);
+  await modal.getByTestId('theme-sdg-trigger').click();
+
+  for (let n = 1; n <= 17; n += 1) {
+    const code = `SDG${n}`;
+    const checkbox = modal.getByTestId(`theme-sdg-checkbox-${code}`);
+    assert.equal(await checkbox.count(), 1, `Expected a multi-select checkbox for ${code}`);
+
+    const option = modal.getByTestId(`theme-sdg-option-${code}`);
+    const optionText = (await option.innerText()).replace(/\s+/g, ' ').trim();
+    assert.ok(optionText.includes(code), `Expected the ${code} option to be labelled with its code, got '${optionText}'`);
+    assert.ok(
+      optionText.includes(SDG_LABELS[code]),
+      `Expected the ${code} option to include its Dutch label '${SDG_LABELS[code]}', got '${optionText}'`,
+    );
+  }
+});
+
+Then('the create form should offer an icon dropdown of at least {int} predefined icons', async function (minimum) {
+  const modal = createModal(this);
+  await modal.getByTestId('theme-icon-trigger').click();
+  const count = await modal.getByTestId('theme-icon-option').count();
+  assert.ok(count >= minimum, `Expected at least ${minimum} icon options, found ${count}`);
+});
+
+Then('the create form should show a native color picker with its hex value', async function () {
+  const modal = createModal(this);
+  const colorInput = modal.getByTestId('theme-color-input');
+  assert.equal(await colorInput.getAttribute('type'), 'color', 'Expected a native <input type="color">');
+  const hex = (await modal.getByTestId('theme-color-hex').innerText()).trim();
+  assert.ok(/^#[0-9a-fA-F]{6}$/.test(hex), `Expected a hex value shown beside the picker, got '${hex}'`);
+});
+
+Then('the create form should not show a display order field', async function () {
+  const modal = createModal(this);
+  assert.equal(await modal.getByTestId('theme-display-order-input').count(), 0, 'Expected no display order input in the form');
+  const text = await modal.innerText();
+  assert.ok(!/sorteervolgorde|display.?order|weergavevolgorde/i.test(text), 'Expected no display order field label in the form');
+});
+
+Then('the create request display_order should equal the highest sample display order plus one', async function () {
+  await assert_one_create_request.call(this);
+  const payload = this.createRequests[0];
+  assert.equal(
+    payload.display_order,
+    MAX_SAMPLE_DISPLAY_ORDER + 1,
+    `Expected display_order ${MAX_SAMPLE_DISPLAY_ORDER + 1}, got ${payload.display_order}`,
+  );
+});
+
+Then('the theme create modal should be closed', async function () {
+  await createModal(this).waitFor({ state: 'detached', timeout: 10_000 });
+  assert.equal(await createModal(this).count(), 0, 'Expected the theme create modal to be closed');
+});
+
+Then('a {string} success message should be shown', async function (message) {
+  const toast = page(this).getByRole('alert').filter({ hasText: message });
+  await toast.waitFor({ state: 'visible', timeout: 10_000 });
+  assert.equal(await toast.isVisible(), true, `Expected a success message '${message}'`);
+});
+
+Then('a theme row named {string} should be listed', async function (name) {
+  const row = page(this).getByTestId('theme-row').filter({ hasText: name });
+  await row.waitFor({ state: 'visible', timeout: 10_000 });
+  assert.equal(await row.count(), 1, `Expected exactly one theme row named '${name}'`);
+});
+
+Then('the theme create modal should stay open', async function () {
+  // Give the failed request time to resolve, then confirm the modal is still up.
+  await page(this).waitForTimeout(500);
+  assert.equal(await createModal(this).isVisible(), true, 'Expected the create modal to stay open after a failed save');
+});
+
+Then('the inline create error {string} should be shown', async function (message) {
+  const error = createModal(this).getByTestId('theme-form-error');
+  await error.waitFor({ state: 'visible', timeout: 10_000 });
+  assert.equal((await error.innerText()).trim(), message, `Expected the inline error to read '${message}'`);
+});
+
+Then('no theme create request should have been sent', async function () {
+  assert.ok(Array.isArray(this.createRequests), 'Expected the create endpoint to have been stubbed');
+  assert.equal(this.createRequests.length, 0, `Expected no create requests, but ${this.createRequests.length} were sent`);
+});
+
+Then('the create request sdg_code should equal {string}', async function (expected) {
+  await assert_one_create_request.call(this);
+  assert.equal(this.createRequests[0].sdg_code, expected, `Expected sdg_code '${expected}', got '${this.createRequests[0].sdg_code}'`);
+});
+
+Then('every icon option should render its Material Symbols glyph next to its name', async function () {
+  const modal = createModal(this);
+  const options = await modal.getByTestId('theme-icon-option').all();
+  assert.ok(options.length > 0, 'Expected the icon dropdown to be open with options');
+
+  for (const option of options) {
+    const glyph = option.locator('.material-symbols-outlined');
+    assert.equal(await glyph.count(), 1, 'Expected each icon option to render exactly one Material Symbols glyph');
+
+    const glyphName = (await glyph.innerText()).trim();
+    assert.ok(glyphName.length > 0, 'Expected the glyph to carry the icon ligature name');
+
+    // The visible option text must also show the icon name as readable text
+    // (the ligature is repeated: once as the glyph, once as the readable label).
+    const fullText = (await option.innerText()).replace(/\s+/g, ' ').trim();
+    const label = fullText.replace(glyphName, '').trim();
+    assert.ok(label.length > 0, `Expected the icon name to be shown as text beside the glyph, got '${fullText}'`);
+  }
+});
+
+Then('the color field should be a native color input', async function () {
+  const colorInput = createModal(this).getByTestId('theme-color-input');
+  assert.equal(await colorInput.getAttribute('type'), 'color', 'Expected a native <input type="color">');
+});
+
+Then('the color hex value {string} should be displayed next to the picker', async function (hex) {
+  const hexDisplay = createModal(this).getByTestId('theme-color-hex');
+  await assert.doesNotReject(
+    hexDisplay.filter({ hasText: hex }).waitFor({ state: 'visible', timeout: 5_000 }),
+    `Expected the hex value '${hex}' to be displayed`,
+  );
+  assert.equal((await hexDisplay.innerText()).trim().toLowerCase(), hex.toLowerCase(), `Expected the hex display to read '${hex}'`);
+});
+
+async function assert_one_create_request() {
+  assert.ok(Array.isArray(this.createRequests), 'Expected the create endpoint to have been stubbed');
+  const deadline = Date.now() + 10_000;
+  while (this.createRequests.length === 0 && Date.now() < deadline) {
+    await page(this).waitForTimeout(100);
+  }
+  assert.equal(this.createRequests.length, 1, `Expected exactly one create request, got ${this.createRequests.length}`);
+}

--- a/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
+++ b/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
@@ -60,6 +60,12 @@ Given('the theme catalog contains only the TS-011 baseline themes', async functi
   await resetThemeCatalog();
 });
 
+Given('the theme catalog is empty', async function () {
+  // Exercises the empty-catalog edge of the server's display_order assignment
+  // (max of nothing + 1 = 1) that the baseline scenarios can never reach.
+  await resetThemeCatalog([]);
+});
+
 When('I open the theme create modal', async function () {
   await page(this).getByRole('button', { name: 'Nieuw thema' }).click();
   await createModal(this).waitFor({ state: 'visible' });
@@ -191,6 +197,15 @@ Then('the created theme display_order should equal the highest baseline display 
     created.display_order,
     MAX_BASELINE_DISPLAY_ORDER + 1,
     `Expected the persisted display_order to be ${MAX_BASELINE_DISPLAY_ORDER + 1}, got ${created.display_order}`,
+  );
+});
+
+Then('the created theme display_order should equal {int}', async function (expected) {
+  const created = await waitForThemeByName(this.themeName);
+  assert.equal(
+    created.display_order,
+    expected,
+    `Expected the persisted display_order to be ${expected}, got ${created.display_order}`,
   );
 });
 

--- a/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
+++ b/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
@@ -3,19 +3,23 @@ const assert = require('node:assert/strict');
 const { Given, Then, When } = require('@qavajs/core');
 
 const { E2E_TEACHER_ID } = require('../support/test-data.cjs');
-const { stubThemesEndpoint, stubCreateThemeEndpoint } = require('../support/theme-stub.cjs');
 const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
+const {
+  THEME_SEED_BASELINE,
+  resetThemeCatalog,
+  getThemeByName,
+  waitForThemeByName,
+} = require('../support/theme-catalog.cjs');
 
-// Sample catalog served for GET /themes/. Display orders are deliberately not
-// contiguous and their max (6) is on a theme whose name is not last
-// alphabetically, so "max display order + 1" (AC-3) is an unambiguous target.
-const SAMPLE_THEMES = [
-  { id: 'ts011-duurzaamheid', name: 'Duurzaamheid', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Duurzame praktijken.' },
-  { id: 'ts011-klimaat', name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: 'Klimaat en milieu.' },
-  { id: 'ts011-innovatie', name: 'Innovatie', sdg_code: 'SDG9', icon: 'lightbulb', color: '#9C27B0', display_order: 6, description: 'Innovatie en technologie.' },
-];
-
-const MAX_SAMPLE_DISPLAY_ORDER = Math.max(...SAMPLE_THEMES.map((theme) => theme.display_order));
+// This suite runs entirely against the real backend: the create happy path, the
+// auto-assigned display_order and the comma-joined SDG code are asserted on what
+// the backend actually persisted, and the AC-5/AC-6 error states are the real
+// 400s the backend returns for an empty and a duplicate name. Nothing is stubbed,
+// so the real POST /themes contract (including its slash redirect) is exercised.
+//
+// The shared baseline's highest display_order is on a theme whose name is not
+// last alphabetically, so "max display order + 1" (AC-3) is an unambiguous target.
+const MAX_BASELINE_DISPLAY_ORDER = Math.max(...THEME_SEED_BASELINE.map((theme) => theme.display_order));
 
 // Canonical Dutch SDG labels (issue example "SDG1 — Geen armoede" +
 // THEME_SDG_IMPLEMENTATION_PLAN.md §3.1). Hardcoded here on purpose so the
@@ -49,16 +53,11 @@ Given('I am authenticated in the browser as the TS-task-011 teacher', async func
   await authenticateInBrowser(this, E2E_TEACHER_ID);
 });
 
-Given('the themes endpoint returns the TS-task-011 sample catalog', async function () {
-  await stubThemesEndpoint(page(this), { status: 200, body: SAMPLE_THEMES });
-});
-
-Given('the theme create endpoint will succeed', async function () {
-  this.createRequests = await stubCreateThemeEndpoint(page(this), { status: 201 });
-});
-
-Given('the theme create endpoint will fail with status {int} and message {string}', async function (status, message) {
-  this.createRequests = await stubCreateThemeEndpoint(page(this), { status, detail: message });
+Given('the theme catalog contains only the TS-011 baseline themes', async function () {
+  // Real backend: reset to the shared deterministic baseline so the create form
+  // sees a known catalog (fixed max display_order, and an existing
+  // "Duurzaamheid" for the duplicate-name scenario).
+  await resetThemeCatalog();
 });
 
 When('I open the theme create modal', async function () {
@@ -67,6 +66,8 @@ When('I open the theme create modal', async function () {
 });
 
 When('I fill in the theme name {string}', async function (name) {
+  // Remembered so the persisted-theme assertions know which theme to read back.
+  this.themeName = name;
   await createModal(this).getByTestId('theme-name-input').fill(name);
 });
 
@@ -184,13 +185,12 @@ Then('the create form should not show a display order field', async function () 
   assert.ok(!/sorteervolgorde|display.?order|weergavevolgorde/i.test(text), 'Expected no display order field label in the form');
 });
 
-Then('the create request display_order should equal the highest sample display order plus one', async function () {
-  await assert_one_create_request.call(this);
-  const payload = this.createRequests[0];
+Then('the created theme display_order should equal the highest baseline display order plus one', async function () {
+  const created = await waitForThemeByName(this.themeName);
   assert.equal(
-    payload.display_order,
-    MAX_SAMPLE_DISPLAY_ORDER + 1,
-    `Expected display_order ${MAX_SAMPLE_DISPLAY_ORDER + 1}, got ${payload.display_order}`,
+    created.display_order,
+    MAX_BASELINE_DISPLAY_ORDER + 1,
+    `Expected the persisted display_order to be ${MAX_BASELINE_DISPLAY_ORDER + 1}, got ${created.display_order}`,
   );
 });
 
@@ -223,14 +223,15 @@ Then('the inline create error {string} should be shown', async function (message
   assert.equal((await error.innerText()).trim(), message, `Expected the inline error to read '${message}'`);
 });
 
-Then('no theme create request should have been sent', async function () {
-  assert.ok(Array.isArray(this.createRequests), 'Expected the create endpoint to have been stubbed');
-  assert.equal(this.createRequests.length, 0, `Expected no create requests, but ${this.createRequests.length} were sent`);
+Then('no theme named {string} should exist', async function (name) {
+  // Give any (unwanted) in-flight create a chance to land before asserting absence.
+  await page(this).waitForTimeout(500);
+  assert.equal(await getThemeByName(name), null, `Expected no theme named '${name}' to have been created`);
 });
 
-Then('the create request sdg_code should equal {string}', async function (expected) {
-  await assert_one_create_request.call(this);
-  assert.equal(this.createRequests[0].sdg_code, expected, `Expected sdg_code '${expected}', got '${this.createRequests[0].sdg_code}'`);
+Then('the created theme sdg_code should equal {string}', async function (expected) {
+  const created = await waitForThemeByName(this.themeName);
+  assert.equal(created.sdg_code, expected, `Expected the persisted sdg_code to be '${expected}', got '${created.sdg_code}'`);
 });
 
 Then('every icon option should render its Material Symbols glyph next to its name', async function () {
@@ -266,12 +267,3 @@ Then('the color hex value {string} should be displayed next to the picker', asyn
   );
   assert.equal((await hexDisplay.innerText()).trim().toLowerCase(), hex.toLowerCase(), `Expected the hex display to read '${hex}'`);
 });
-
-async function assert_one_create_request() {
-  assert.ok(Array.isArray(this.createRequests), 'Expected the create endpoint to have been stubbed');
-  const deadline = Date.now() + 10_000;
-  while (this.createRequests.length === 0 && Date.now() < deadline) {
-    await page(this).waitForTimeout(100);
-  }
-  assert.equal(this.createRequests.length, 1, `Expected exactly one create request, got ${this.createRequests.length}`);
-}

--- a/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
+++ b/tests/e2e/steps/ts-task-011-theme-create-modal.steps.cjs
@@ -6,6 +6,7 @@ const { E2E_TEACHER_ID } = require('../support/test-data.cjs');
 const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
 const {
   THEME_SEED_BASELINE,
+  BASELINE_DUPLICATE_NAME,
   resetThemeCatalog,
   getThemeByName,
   waitForThemeByName,
@@ -49,6 +50,16 @@ function createModal(world) {
   return page(world).getByTestId('theme-create-modal');
 }
 
+/**
+ * Read back the theme the scenario just created. Guards the implicit coupling to
+ * the fill step: without it, a scenario that reads back without filling a name
+ * polls for ten seconds and then fails with "a theme named 'undefined'".
+ */
+async function readCreatedTheme(world) {
+  assert.ok(world.themeName, 'Expected the scenario to fill in a theme name before reading the created theme back');
+  return waitForThemeByName(world.themeName);
+}
+
 Given('I am authenticated in the browser as the TS-task-011 teacher', async function () {
   await authenticateInBrowser(this, E2E_TEACHER_ID);
 });
@@ -60,11 +71,6 @@ Given('the theme catalog contains only the TS-011 baseline themes', async functi
   await resetThemeCatalog();
 });
 
-Given('the theme catalog is empty', async function () {
-  // Exercises the empty-catalog edge of the server's display_order assignment
-  // (max of nothing + 1 = 1) that the baseline scenarios can never reach.
-  await resetThemeCatalog([]);
-});
 
 When('I open the theme create modal', async function () {
   await page(this).getByRole('button', { name: 'Nieuw thema' }).click();
@@ -75,6 +81,13 @@ When('I fill in the theme name {string}', async function (name) {
   // Remembered so the persisted-theme assertions know which theme to read back.
   this.themeName = name;
   await createModal(this).getByTestId('theme-name-input').fill(name);
+});
+
+When('I fill in the theme name of an existing theme', async function () {
+  // Derived from the baseline so the duplicate-name scenario cannot silently
+  // decouple from the fixture it depends on.
+  this.themeName = BASELINE_DUPLICATE_NAME;
+  await createModal(this).getByTestId('theme-name-input').fill(BASELINE_DUPLICATE_NAME);
 });
 
 When('I save the new theme', async function () {
@@ -192,7 +205,7 @@ Then('the create form should not show a display order field', async function () 
 });
 
 Then('the created theme display_order should equal the highest baseline display order plus one', async function () {
-  const created = await waitForThemeByName(this.themeName);
+  const created = await readCreatedTheme(this);
   assert.equal(
     created.display_order,
     MAX_BASELINE_DISPLAY_ORDER + 1,
@@ -201,7 +214,7 @@ Then('the created theme display_order should equal the highest baseline display 
 });
 
 Then('the created theme display_order should equal {int}', async function (expected) {
-  const created = await waitForThemeByName(this.themeName);
+  const created = await readCreatedTheme(this);
   assert.equal(
     created.display_order,
     expected,
@@ -227,8 +240,9 @@ Then('a theme row named {string} should be listed', async function (name) {
 });
 
 Then('the theme create modal should stay open', async function () {
-  // Give the failed request time to resolve, then confirm the modal is still up.
-  await page(this).waitForTimeout(500);
+  // Ordered after the inline-error assertion, which waits for the failed response
+  // to render. The save has therefore already resolved, so a still-visible modal
+  // is a real assertion rather than a sleep racing the request.
   assert.equal(await createModal(this).isVisible(), true, 'Expected the create modal to stay open after a failed save');
 });
 
@@ -245,28 +259,51 @@ Then('no theme named {string} should exist', async function (name) {
 });
 
 Then('the created theme sdg_code should equal {string}', async function (expected) {
-  const created = await waitForThemeByName(this.themeName);
+  const created = await readCreatedTheme(this);
   assert.equal(created.sdg_code, expected, `Expected the persisted sdg_code to be '${expected}', got '${created.sdg_code}'`);
 });
 
 Then('every icon option should render its Material Symbols glyph next to its name', async function () {
   const modal = createModal(this);
-  const options = await modal.getByTestId('theme-icon-option').all();
-  assert.ok(options.length > 0, 'Expected the icon dropdown to be open with options');
+  await modal.getByTestId('theme-icon-option').first().waitFor({ state: 'visible' });
 
-  for (const option of options) {
-    const glyph = option.locator('.material-symbols-outlined');
-    assert.equal(await glyph.count(), 1, 'Expected each icon option to render exactly one Material Symbols glyph');
+  // Inspected in a single round trip: walking ~90 options through the driver with
+  // three calls each was slow and proved nothing extra.
+  //
+  // This asserts structure, not pixels: each option carries exactly one icon-font
+  // element whose ligature is the icon name, plus that same name as separate
+  // readable text. It deliberately does NOT assert that the font itself painted a
+  // glyph - Material Symbols is loaded from the Google Fonts CDN (index.html), so
+  // any such check would fail whenever the runner is offline or the CDN blips,
+  // trading a real bug for a flake in a suite built to be deterministic.
+  const { total, offenders } = await modal.evaluate((root) => {
+    const options = [...root.querySelectorAll('[data-testid="theme-icon-option"]')];
+    const bad = [];
 
-    const glyphName = (await glyph.innerText()).trim();
-    assert.ok(glyphName.length > 0, 'Expected the glyph to carry the icon ligature name');
+    for (const option of options) {
+      const glyphs = option.querySelectorAll('.material-symbols-outlined');
+      const ligature = glyphs.length === 1 ? (glyphs[0].textContent || '').trim() : '';
+      const label = [...option.children]
+        .filter((child) => !child.classList.contains('material-symbols-outlined'))
+        .map((child) => (child.textContent || '').trim())
+        .join(' ')
+        .trim();
 
-    // The visible option text must also show the icon name as readable text
-    // (the ligature is repeated: once as the glyph, once as the readable label).
-    const fullText = (await option.innerText()).replace(/\s+/g, ' ').trim();
-    const label = fullText.replace(glyphName, '').trim();
-    assert.ok(label.length > 0, `Expected the icon name to be shown as text beside the glyph, got '${fullText}'`);
-  }
+      // The readable label must name the same icon the ligature renders.
+      if (glyphs.length !== 1 || !ligature || !label || label !== ligature) {
+        bad.push({ text: (option.textContent || '').trim(), glyphs: glyphs.length, ligature, label });
+      }
+    }
+
+    return { total: options.length, offenders: bad.slice(0, 5) };
+  });
+
+  assert.ok(total > 0, 'Expected the icon dropdown to be open with options');
+  assert.deepEqual(
+    offenders,
+    [],
+    `Expected every icon option to render one icon-font glyph beside its readable name; first offenders: ${JSON.stringify(offenders)}`,
+  );
 });
 
 Then('the color field should be a native color input', async function () {

--- a/tests/e2e/support/e2e-session.cjs
+++ b/tests/e2e/support/e2e-session.cjs
@@ -1,0 +1,37 @@
+// Shared browser-session helpers for the E2E suites.
+//
+// Promoted out of the per-task step files once TS-task-011 became the real
+// second consumer of the TS-task-010 teacher-login/session logic, so the two
+// suites share one implementation instead of copies.
+
+const assert = require('node:assert/strict');
+
+const { BACKEND_URL, FRONTEND_URL } = require('./test-data.cjs');
+
+/** Resolve the Playwright page the qavajs world exposes. */
+function page(world) {
+  const current = world?.playwright?.page;
+  assert.ok(current, 'Expected the qavajs world to expose playwright.page');
+  return current;
+}
+
+/** Exchange a seeded user id for a JWT via the localhost test-login endpoint. */
+async function loginToken(userId) {
+  const response = await fetch(`${BACKEND_URL}/auth/test/login/${userId}`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  });
+  assert.equal(response.status, 200, `Expected test login for ${userId} to return 200, received ${response.status}`);
+  const payload = await response.json();
+  assert.ok(payload?.access_token, `Expected test login for ${userId} to return an access_token`);
+  return payload.access_token;
+}
+
+/** Authenticate the browser as a seeded user by storing its token. */
+async function authenticateInBrowser(world, userId) {
+  const token = await loginToken(userId);
+  await page(world).goto(FRONTEND_URL);
+  await page(world).evaluate((authToken) => localStorage.setItem('token', authToken), token);
+}
+
+module.exports = { page, loginToken, authenticateInBrowser };

--- a/tests/e2e/support/theme-catalog.cjs
+++ b/tests/e2e/support/theme-catalog.cjs
@@ -1,0 +1,117 @@
+// Real-backend theme catalog control for the theme management UI suites.
+//
+// The E2E TypeDB seed holds no themes, and the theme-integrity API scenarios
+// create themes without per-scenario cleanup, so the live catalog is
+// order-dependent. To drive the theme management UI against the real backend
+// deterministically, this helper resets the catalog to a known baseline: it
+// deletes every existing theme and recreates a fixed fixture set through the
+// real, teacher-authenticated theme API.
+//
+// This is the theme analogue of the portfolio reset contract (PF-task-004):
+// real backend + known fixtures + reset-to-baseline. Network stubs are reserved
+// only for the states the real backend cannot produce on demand (loading,
+// fetch error, empty catalog) and live in theme-stub.cjs.
+//
+// DELETE /themes/{id} first removes the theme's hasTheme links and then the
+// theme, so wiping a catalog whose themes are linked to projects is safe. Both
+// theme suites re-establish their own preconditions per scenario, so resetting
+// the shared catalog between scenarios does not leak state across suites.
+
+const assert = require('node:assert/strict');
+
+const { BACKEND_URL, E2E_TEACHER_ID } = require('./test-data.cjs');
+const { loginToken } = require('./e2e-session.cjs');
+
+// One description is deliberately long so the list-truncation assertion has
+// something to truncate; kept here as the single source of truth for TS-010.
+const LONG_DESCRIPTION =
+  'Dit is een opzettelijk zeer lange themabeschrijving die ruim voorbij de afkapgrens loopt zodat de weergave de tekst zichtbaar moet inkorten in de lijst.';
+
+// Deterministic baseline catalog for the TS-task-010 list scenarios. Display
+// orders are non-contiguous and include a tie (3) whose names are NOT
+// alphabetical (Alpha before Bravo), so "sorted by display_order then name" is
+// an unambiguous, non-trivial assertion. No `id` is included: the backend
+// assigns ids on create, and the UI assertions key off names, not ids.
+const THEME_SEED_BASELINE = Object.freeze([
+  Object.freeze({ name: 'Onderwijs', sdg_code: 'SDG4', icon: 'school', color: '#E91E63', display_order: 6, description: 'Educatie en kennisoverdracht.' }),
+  Object.freeze({ name: 'Bravo Thema', sdg_code: 'SDG9', icon: 'lightbulb', color: '#9C27B0', display_order: 3, description: 'Beschrijving bravo.' }),
+  Object.freeze({ name: 'Duurzaamheid', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Duurzame praktijken.' }),
+  Object.freeze({ name: 'Water', sdg_code: 'SDG14', icon: 'water_drop', color: '#00BCD4', display_order: 5, description: 'Waterbeheer en biodiversiteit.' }),
+  Object.freeze({ name: 'Alpha Thema', sdg_code: 'SDG2', icon: 'restaurant', color: '#FF9800', display_order: 3, description: 'Beschrijving alpha.' }),
+  Object.freeze({ name: 'Klimaat & Milieu', sdg_code: 'SDG13', icon: 'public', color: '#2196F3', display_order: 2, description: LONG_DESCRIPTION }),
+]);
+
+// Expected teacher-visible order: display_order ascending, then name. Alpha
+// Thema precedes Bravo Thema at the shared display_order 3. Written out on
+// purpose so the assertion does not merely mirror the component comparator.
+const EXPECTED_SORTED_NAMES = Object.freeze([
+  'Duurzaamheid', // 1
+  'Klimaat & Milieu', // 2
+  'Alpha Thema', // 3 (tie, name-first)
+  'Bravo Thema', // 3 (tie)
+  'Water', // 5
+  'Onderwijs', // 6
+]);
+
+async function themeApi(pathname, token, options = {}) {
+  const headers = {
+    Accept: 'application/json',
+    ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+  const response = await fetch(`${BACKEND_URL}${pathname}`, { ...options, headers });
+  const text = await response.text();
+  // Keep the raw text on non-JSON bodies (e.g. a 500 "Internal Server Error")
+  // so callers fail on the unexpected status with a readable message instead of
+  // an opaque JSON.parse crash.
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  return { status: response.status, body };
+}
+
+/**
+ * Reset the live theme catalog to exactly `baseline`: delete every existing
+ * theme, then recreate the baseline set via the real teacher-authenticated API.
+ *
+ * Uses the trailing-slash `/themes/` collection URL that the backend router
+ * exposes, so no 307 redirect is involved.
+ *
+ * @param {ReadonlyArray<object>} [baseline]
+ * @returns {Promise<Array<object>>} the created theme records (with backend ids)
+ */
+async function resetThemeCatalog(baseline = THEME_SEED_BASELINE) {
+  const token = await loginToken(E2E_TEACHER_ID);
+
+  const existing = await themeApi('/themes/', token);
+  assert.equal(existing.status, 200, `Expected GET /themes/ during reset to return 200, received ${existing.status}`);
+  assert.ok(Array.isArray(existing.body), `Expected GET /themes/ during reset to return an array, received ${JSON.stringify(existing.body)}`);
+
+  for (const theme of existing.body) {
+    if (!theme?.id) continue;
+    const deleted = await themeApi(`/themes/${theme.id}`, token, { method: 'DELETE' });
+    assert.ok(
+      deleted.status === 200 || deleted.status === 404,
+      `Expected DELETE /themes/${theme.id} during reset to return 200 or 404, received ${deleted.status}`,
+    );
+  }
+
+  const created = [];
+  for (const theme of baseline) {
+    const result = await themeApi('/themes/', token, { method: 'POST', body: JSON.stringify(theme) });
+    assert.equal(
+      result.status,
+      201,
+      `Expected POST /themes/ during reset to return 201, received ${result.status}: ${JSON.stringify(result.body)}`,
+    );
+    created.push(result.body);
+  }
+  return created;
+}
+
+module.exports = { THEME_SEED_BASELINE, EXPECTED_SORTED_NAMES, LONG_DESCRIPTION, resetThemeCatalog };

--- a/tests/e2e/support/theme-catalog.cjs
+++ b/tests/e2e/support/theme-catalog.cjs
@@ -114,4 +114,40 @@ async function resetThemeCatalog(baseline = THEME_SEED_BASELINE) {
   return created;
 }
 
-module.exports = { THEME_SEED_BASELINE, EXPECTED_SORTED_NAMES, LONG_DESCRIPTION, resetThemeCatalog };
+/** Read the live theme catalog via the public GET /themes/ endpoint. */
+async function fetchThemes() {
+  const result = await themeApi('/themes/', null);
+  assert.equal(result.status, 200, `Expected GET /themes/ to return 200, received ${result.status}: ${JSON.stringify(result.body)}`);
+  assert.ok(Array.isArray(result.body), `Expected GET /themes/ to return an array, received ${JSON.stringify(result.body)}`);
+  return result.body;
+}
+
+/** Find a persisted theme by exact name, or null when it does not exist. */
+async function getThemeByName(name) {
+  const themes = await fetchThemes();
+  return themes.find((theme) => theme?.name === name) ?? null;
+}
+
+/**
+ * Poll until a theme with `name` is persisted, so assertions on what the UI
+ * actually saved do not race the browser's in-flight create request.
+ */
+async function waitForThemeByName(name, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const theme = await getThemeByName(name);
+    if (theme) return theme;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  assert.fail(`Expected a theme named '${name}' to be persisted within ${timeoutMs}ms`);
+}
+
+module.exports = {
+  THEME_SEED_BASELINE,
+  EXPECTED_SORTED_NAMES,
+  LONG_DESCRIPTION,
+  resetThemeCatalog,
+  fetchThemes,
+  getThemeByName,
+  waitForThemeByName,
+};

--- a/tests/e2e/support/theme-catalog.cjs
+++ b/tests/e2e/support/theme-catalog.cjs
@@ -9,13 +9,17 @@
 //
 // This is the theme analogue of the portfolio reset contract (PF-task-004):
 // real backend + known fixtures + reset-to-baseline. Network stubs are reserved
-// only for the states the real backend cannot produce on demand (loading,
-// fetch error, empty catalog) and live in theme-stub.cjs.
+// only for the states the real backend cannot produce on demand - a slow
+// response and a failed fetch - and live in theme-stub.cjs.
 //
 // DELETE /themes/{id} first removes the theme's hasTheme links and then the
-// theme, so wiping a catalog whose themes are linked to projects is safe. Both
-// theme suites re-establish their own preconditions per scenario, so resetting
-// the shared catalog between scenarios does not leak state across suites.
+// theme, so wiping a catalog whose themes are linked to projects is safe.
+//
+// The invariant this reset depends on is SERIAL execution (parallel: 1 in
+// qavajs.config.cjs). Every theme suite re-establishes its own preconditions per
+// scenario, so a wipe between scenarios is harmless; with parallel > 1 this would
+// delete themes out from under a concurrent theme-integrity scenario, between its
+// setup and its assertion. It does NOT depend on feature file ordering.
 
 const assert = require('node:assert/strict');
 
@@ -52,6 +56,17 @@ const EXPECTED_SORTED_NAMES = Object.freeze([
   'Water', // 5
   'Onderwijs', // 6
 ]);
+
+// The existing theme the duplicate-name scenario (TS-task-011 AC-6) re-creates.
+// Guarded against the baseline rather than hardcoded in the feature, so renaming
+// a fixture fails here immediately instead of surfacing far away as a confusing
+// "expected an inline error, but the modal closed".
+const BASELINE_DUPLICATE_NAME = 'Duurzaamheid';
+
+assert.ok(
+  THEME_SEED_BASELINE.some((theme) => theme.name === BASELINE_DUPLICATE_NAME),
+  `The theme baseline must contain '${BASELINE_DUPLICATE_NAME}' for the duplicate-name scenario (TS-task-011 AC-6)`,
+);
 
 async function themeApi(pathname, token, options = {}) {
   const headers = {
@@ -146,6 +161,7 @@ module.exports = {
   THEME_SEED_BASELINE,
   EXPECTED_SORTED_NAMES,
   LONG_DESCRIPTION,
+  BASELINE_DUPLICATE_NAME,
   resetThemeCatalog,
   fetchThemes,
   getThemeByName,

--- a/tests/e2e/support/theme-stub.cjs
+++ b/tests/e2e/support/theme-stub.cjs
@@ -1,13 +1,13 @@
 // Reusable Playwright network stub for the public GET /themes/ collection endpoint.
 //
-// The isolated E2E TypeDB seed contains no themes, and the existing theme
-// integrity scenarios mutate the shared theme catalog without per-scenario
-// cleanup. Driving theme-list UI states from that shared, mutable catalog would
-// be order-dependent and could never produce a loading/error state on demand.
+// Theme UI scenarios run against the real backend and reset the catalog to a
+// deterministic baseline (see theme-catalog.cjs). This stub is reserved for the
+// few states a healthy backend cannot produce on demand: a slow response
+// (loading indicator), a failed fetch (error state), and an empty catalog.
 //
-// This helper lets any theme UI scenario deterministically control what
-// GET /themes/ returns. It is intentionally generic so the sibling theme UI
-// tasks (TS-task-011/012/013 modals, the theme display tasks) can reuse it.
+// Prefer the real backend + resetThemeCatalog() for anything else: a stub can
+// only prove "given the API responds like this, the UI does that", never that
+// the frontend and backend actually agree.
 
 // getThemes() calls `${API_BASE_URL}themes/` (always a trailing slash and no
 // query string in this app); this matches exactly that collection request and
@@ -39,66 +39,4 @@ async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0 }
   });
 }
 
-// createTheme() posts to `${API_BASE_URL}themes` (no trailing slash), which is
-// exactly the collection resource without a slash and never `/themes/`,
-// `/themes/:id` or `/themes/project/:id`. Matching on the missing trailing
-// slash keeps this stub disjoint from stubThemesEndpoint above.
-const CREATE_THEME_ROUTE = /\/themes$/;
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST,OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization,content-type',
-};
-
-/**
- * Intercept POST /themes and record every create request the form sends.
- *
- * The cross-origin JSON+Authorization POST triggers a CORS preflight, so the
- * OPTIONS request is answered here too; otherwise the real POST would be
- * blocked and the happy path could never reach the stub.
- *
- * @param {import('playwright').Page} page
- * @param {{ status?: number, detail?: string, body?: unknown }} [options]
- * @returns {Array<object>} a live array that collects each parsed request body
- */
-async function stubCreateThemeEndpoint(page, { status = 201, detail, body } = {}) {
-  const requests = [];
-  await page.unroute(CREATE_THEME_ROUTE).catch(() => {});
-  await page.route(CREATE_THEME_ROUTE, async (route) => {
-    const request = route.request();
-
-    if (request.method() === 'OPTIONS') {
-      await route.fulfill({ status: 204, headers: CORS_HEADERS });
-      return;
-    }
-
-    if (request.method() !== 'POST') {
-      await route.fallback();
-      return;
-    }
-
-    let payload = null;
-    try {
-      payload = JSON.parse(request.postData() || 'null');
-    } catch {
-      payload = null;
-    }
-    requests.push(payload);
-
-    // On success echo the payload back as the created resource (mirrors the
-    // backend response_model=Theme) so the UI can render the new row.
-    const responseBody =
-      body ?? (status < 400 ? { id: `ts011-created-${requests.length}`, ...payload } : { detail: detail ?? 'error' });
-
-    await route.fulfill({
-      status,
-      contentType: 'application/json',
-      headers: CORS_HEADERS,
-      body: JSON.stringify(responseBody),
-    });
-  });
-  return requests;
-}
-
-module.exports = { stubThemesEndpoint, THEMES_ROUTE, stubCreateThemeEndpoint, CREATE_THEME_ROUTE };
+module.exports = { stubThemesEndpoint, THEMES_ROUTE };

--- a/tests/e2e/support/theme-stub.cjs
+++ b/tests/e2e/support/theme-stub.cjs
@@ -1,0 +1,42 @@
+// Reusable Playwright network stub for the public GET /themes/ collection endpoint.
+//
+// The isolated E2E TypeDB seed contains no themes, and the existing theme
+// integrity scenarios mutate the shared theme catalog without per-scenario
+// cleanup. Driving theme-list UI states from that shared, mutable catalog would
+// be order-dependent and could never produce a loading/error state on demand.
+//
+// This helper lets any theme UI scenario deterministically control what
+// GET /themes/ returns. It is intentionally generic so the sibling theme UI
+// tasks (TS-task-011/012/013 modals, the theme display tasks) can reuse it.
+
+// getThemes() calls `${API_BASE_URL}themes/` (always a trailing slash and no
+// query string in this app); this matches exactly that collection request and
+// deliberately NOT `/themes/project/:id` or `/themes/:id`.
+const THEMES_ROUTE = /\/themes\/(\?.*)?$/;
+
+/**
+ * Intercept GET /themes/ for a page and fulfil it with a controlled response.
+ *
+ * @param {import('playwright').Page} page
+ * @param {{ status?: number, body?: unknown, delayMs?: number, allowOrigin?: string }} [options]
+ */
+async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0, allowOrigin = '*' } = {}) {
+  // Drop any previously installed themes stub so scenarios can re-stub cleanly.
+  await page.unroute(THEMES_ROUTE).catch(() => {});
+  await page.route(THEMES_ROUTE, async (route) => {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      // The frontend (:10121) fetches the backend (:10122) cross-origin, so the
+      // fulfilled response must expose CORS or the browser fetch would reject
+      // and the happy-path scenarios would incorrectly fall into the error state.
+      headers: { 'Access-Control-Allow-Origin': allowOrigin },
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+module.exports = { stubThemesEndpoint, THEMES_ROUTE };

--- a/tests/e2e/support/theme-stub.cjs
+++ b/tests/e2e/support/theme-stub.cjs
@@ -39,4 +39,66 @@ async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0 }
   });
 }
 
-module.exports = { stubThemesEndpoint, THEMES_ROUTE };
+// createTheme() posts to `${API_BASE_URL}themes` (no trailing slash), which is
+// exactly the collection resource without a slash and never `/themes/`,
+// `/themes/:id` or `/themes/project/:id`. Matching on the missing trailing
+// slash keeps this stub disjoint from stubThemesEndpoint above.
+const CREATE_THEME_ROUTE = /\/themes$/;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization,content-type',
+};
+
+/**
+ * Intercept POST /themes and record every create request the form sends.
+ *
+ * The cross-origin JSON+Authorization POST triggers a CORS preflight, so the
+ * OPTIONS request is answered here too; otherwise the real POST would be
+ * blocked and the happy path could never reach the stub.
+ *
+ * @param {import('playwright').Page} page
+ * @param {{ status?: number, detail?: string, body?: unknown }} [options]
+ * @returns {Array<object>} a live array that collects each parsed request body
+ */
+async function stubCreateThemeEndpoint(page, { status = 201, detail, body } = {}) {
+  const requests = [];
+  await page.unroute(CREATE_THEME_ROUTE).catch(() => {});
+  await page.route(CREATE_THEME_ROUTE, async (route) => {
+    const request = route.request();
+
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+
+    if (request.method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+
+    let payload = null;
+    try {
+      payload = JSON.parse(request.postData() || 'null');
+    } catch {
+      payload = null;
+    }
+    requests.push(payload);
+
+    // On success echo the payload back as the created resource (mirrors the
+    // backend response_model=Theme) so the UI can render the new row.
+    const responseBody =
+      body ?? (status < 400 ? { id: `ts011-created-${requests.length}`, ...payload } : { detail: detail ?? 'error' });
+
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      headers: CORS_HEADERS,
+      body: JSON.stringify(responseBody),
+    });
+  });
+  return requests;
+}
+
+module.exports = { stubThemesEndpoint, THEMES_ROUTE, stubCreateThemeEndpoint, CREATE_THEME_ROUTE };

--- a/tests/e2e/support/theme-stub.cjs
+++ b/tests/e2e/support/theme-stub.cjs
@@ -18,9 +18,9 @@ const THEMES_ROUTE = /\/themes\/(\?.*)?$/;
  * Intercept GET /themes/ for a page and fulfil it with a controlled response.
  *
  * @param {import('playwright').Page} page
- * @param {{ status?: number, body?: unknown, delayMs?: number, allowOrigin?: string }} [options]
+ * @param {{ status?: number, body?: unknown, delayMs?: number }} [options]
  */
-async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0, allowOrigin = '*' } = {}) {
+async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0 } = {}) {
   // Drop any previously installed themes stub so scenarios can re-stub cleanly.
   await page.unroute(THEMES_ROUTE).catch(() => {});
   await page.route(THEMES_ROUTE, async (route) => {
@@ -33,7 +33,7 @@ async function stubThemesEndpoint(page, { status = 200, body = [], delayMs = 0, 
       // The frontend (:10121) fetches the backend (:10122) cross-origin, so the
       // fulfilled response must expose CORS or the browser fetch would reject
       // and the happy-path scenarios would incorrectly fall into the error state.
-      headers: { 'Access-Control-Allow-Origin': allowOrigin },
+      headers: { 'Access-Control-Allow-Origin': '*' },
       body: JSON.stringify(body),
     });
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers TS-task-010 (theme catalog list) and TS-task-011 (theme create modal) for the teacher-facing admin page, along with a set of backend improvements to `theme_repository.py` that were needed to make the create flow correct.

- **Backend (`theme_repository.py`)**: A single `get_all()` call now serves both the case-insensitive duplicate check and the `display_order` auto-assignment, so both decisions work from the same snapshot. A `TypeDBDriverException` catch acts as a TOCTOU backstop (the schema's `@unique` on `name` rejects the losing concurrent insert and gets surfaced as a clean `ValueError` → 400 rather than a 500). The TypeDB 3.x `delete` statements are corrected (dropping the redundant `isa` clause), and the returned `Theme` now carries the server-computed `display_order` instead of the client-supplied one.
- **Frontend**: `ThemeManagement.jsx` renders the catalog with loading/error/empty states and a count that is only shown once data has loaded. `ThemeCreateModal.jsx` is a `<form onSubmit>`-wrapped create form with a client-side name guard, an auto-closing icon `<details>` picker, and an SDG multi-select — no `display_order` field (server assigns it).
- **E2E tests**: Comprehensive TS-010 and TS-011 test suites run entirely against the real backend for the happy paths and use stubs only for states (loading/error/empty) that cannot be reproduced against a healthy stack.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the backend changes are well-reasoned fixes and the new frontend components are straightforward with no broken flows.

The backend refactor correctly shares a single catalog snapshot for the duplicate check and display_order assignment, and the TypeDBDriverException handler closes the previously-discussed TOCTOU gap without masking unrelated errors. The new React components follow established codebase patterns, the form onSubmit and type submit button address the prior WCAG comment, and the loading/error/empty states are correctly guarded. The only finding is a minor SDG toggle stale-closure that cannot cause a real bug under normal user interaction.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| projojo_backend/domain/repositories/theme_repository.py | Refactors duplicate-name check and display_order assignment to share a single catalog snapshot, adds a TypeDBDriverException backstop for the TOCTOU race, fixes TypeDB 3.x delete syntax, and corrects the returned Theme's display_order to use the server-computed value. |
| projojo_frontend/src/components/ThemeCreateModal.jsx | New component (TS-011): teacher-facing create form with form onSubmit, type=submit save button, client-side name guard, and proper ARIA attributes. Addresses previous form/WCAG comment. Minor stale-closure nit in toggleSdg. |
| projojo_frontend/src/components/ThemeManagement.jsx | New component (TS-010): theme catalog list with loading/error/empty states, optimistic insert on creation, and count paragraph correctly guarded behind !isLoading && !error. |
| projojo_frontend/src/pages/TeacherPage.jsx | Adds ThemeManagement import and renders the component below the skills section — minimal, correct wiring. |
| projojo_frontend/src/services.js | Adds getThemes() (public, raw fetch) and createTheme() (teacher-auth via fetchWithError) service functions, consistent with existing patterns. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `projojo_frontend/src/components/ThemeManagement.jsx`, line 442-444 ([link](https://github.com/han-aim-cmd-wg/projojo/blob/e478433f522639a2d8a3fe8e49fdf23ca4dc7b73/projojo_frontend/src/components/ThemeManagement.jsx#L442-L444)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Count paragraph shows "0 thema's" during the loading phase**

   `themes` is initialised to `[]` and the count paragraph (`Er zijn 0 thema's in de catalogus.`) lives outside the `isLoading` conditional, so it renders immediately on mount before the fetch resolves. A user briefly sees "Er zijn 0 thema's in de catalogus." while the spinner is also visible, which is contradictory. Moving the count paragraph inside the non-loading, non-error branch (or suppressing it while `isLoading`) would keep the message accurate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: projojo_frontend/src/components/ThemeManagement.jsx
   Line: 442-444

   Comment:
   **Count paragraph shows "0 thema's" during the loading phase**

   `themes` is initialised to `[]` and the count paragraph (`Er zijn 0 thema's in de catalogus.`) lives outside the `isLoading` conditional, so it renders immediately on mount before the fetch resolves. A user briefly sees "Er zijn 0 thema's in de catalogus." while the spinner is also visible, which is contradictory. Moving the count paragraph inside the non-loading, non-error branch (or suppressing it while `isLoading`) would keep the message accurate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["add TOCTOU backstop"](https://github.com/han-aim-cmd-wg/projojo/commit/fb16f4bdc68a5dba16891bb1326767e4f8a30cc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44645713)</sub>

<!-- /greptile_comment -->