### PR TITLE
a11y improvement modal

### DIFF
--- a/projojo_frontend/src/components/Modal.jsx
+++ b/projojo_frontend/src/components/Modal.jsx
@@ -106,11 +106,15 @@ export default function Modal({
         };
     }, [forceModalStackRender, modalInstanceId]);
 
-    // Focus lifecycle, keyed on isModalOpen alone. handleKeyDown is a fresh
-    // function on every render, so keeping focus restoration out of the stack
-    // effect below (which depends on it) is deliberate: focus is captured once
-    // when the modal opens and restored exactly once when it closes or unmounts.
-    // It is never re-grabbed on an unrelated re-render of the modal's parent.
+    // Focus lifecycle, keyed on isModalOpen alone. Keeping focus restoration out
+    // of the stack effect below (which also depends on handleKeyDown) is
+    // deliberate: focus is captured once when the modal opens and restored
+    // exactly once when it closes or unmounts. Isolating it here means a re-run
+    // of the stack effect can never re-grab focus on an unrelated re-render.
+    // Note: unlike the old single-effect version (which only restored focus on an
+    // explicit true -> false transition), this cleanup also runs when the modal
+    // unmounts while still open (e.g. parent navigates away). This is intentional
+    // for accessibility - focus always returns to the trigger - not a regression.
     useEffect(() => {
         if (!isModalOpen) {
             return;
@@ -129,9 +133,12 @@ export default function Modal({
         };
     }, [isModalOpen]);
 
-    // Stack membership and the keydown listener. This re-runs on every render
-    // (handleKeyDown changes each time), which is harmless: joining the stack and
-    // (re)binding the listener are idempotent and carry no focus side effect.
+    // Stack membership and the keydown listener. handleKeyDown is stable by
+    // default (its useCallback deps isTopModal and setIsModalOpen are both
+    // stable), so this normally only re-runs when isModalOpen changes. Even if a
+    // caller passed an unstable setIsModalOpen, extra re-runs would be harmless:
+    // joining the stack and (re)binding the listener are idempotent, the cleanup
+    // removes the old listener first, and there is no focus side effect here.
     useEffect(() => {
         if (isModalOpen) {
             setStackIndex(addModalToStack(modalInstanceId));

--- a/projojo_frontend/src/components/Modal.jsx
+++ b/projojo_frontend/src/components/Modal.jsx
@@ -42,7 +42,6 @@ export default function Modal({
     const modalRef = useRef(null);
     const closeButtonRef = useRef(null);
     const previousActiveElement = useRef(null);
-    const hasFocusedOnOpen = useRef(false);
     const modalInstanceId = useId();
     const titleId = useId();
     const [stackIndex, setStackIndex] = useState(0);
@@ -107,32 +106,39 @@ export default function Modal({
         };
     }, [forceModalStackRender, modalInstanceId]);
 
+    // Focus lifecycle, keyed on isModalOpen alone. handleKeyDown is a fresh
+    // function on every render, so keeping focus restoration out of the stack
+    // effect below (which depends on it) is deliberate: focus is captured once
+    // when the modal opens and restored exactly once when it closes or unmounts.
+    // It is never re-grabbed on an unrelated re-render of the modal's parent.
+    useEffect(() => {
+        if (!isModalOpen) {
+            return;
+        }
+
+        // Remember what was focused so it can be restored on close, then move
+        // focus onto the close button once the modal has painted.
+        previousActiveElement.current = document.activeElement;
+        const focusTimer = setTimeout(() => {
+            closeButtonRef.current?.focus();
+        }, 0);
+
+        return () => {
+            clearTimeout(focusTimer);
+            previousActiveElement.current?.focus();
+        };
+    }, [isModalOpen]);
+
+    // Stack membership and the keydown listener. This re-runs on every render
+    // (handleKeyDown changes each time), which is harmless: joining the stack and
+    // (re)binding the listener are idempotent and carry no focus side effect.
     useEffect(() => {
         if (isModalOpen) {
             setStackIndex(addModalToStack(modalInstanceId));
-
-            if (!hasFocusedOnOpen.current) {
-                // Store currently focused element to restore later
-                previousActiveElement.current = document.activeElement;
-
-                // Focus the close button after a short delay to ensure modal is rendered
-                setTimeout(() => {
-                    closeButtonRef.current?.focus();
-                }, 0);
-                hasFocusedOnOpen.current = true;
-            }
-
-            // Add keyboard listener
             document.addEventListener('keydown', handleKeyDown);
         } else {
-            hasFocusedOnOpen.current = false;
             removeModalFromStack(modalInstanceId);
             document.removeEventListener('keydown', handleKeyDown);
-
-            // Restore focus to previously focused element
-            if (previousActiveElement.current) {
-                previousActiveElement.current.focus();
-            }
         }
 
         return () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the focus management in `Modal.jsx` by splitting one combined `useEffect` into two dedicated effects: a focus-lifecycle effect (keyed on `isModalOpen` only) and a stack-membership/keydown effect. The `hasFocusedOnOpen` guard ref is removed as it is no longer needed — the new focus effect cannot re-run while the modal stays open.

- **Focus lifecycle effect** captures the previously-focused element and moves focus to the close button on open; its cleanup cancels the timer and restores focus on both explicit close (`true → false`) and component unmount while still open — a deliberate a11y improvement over the old behaviour.
- **Stack/keydown effect** handles `addModalToStack`, `removeModalFromStack`, and the global `keydown` listener; the cleanup removes the listener on every transition, making re-runs harmless.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The refactor correctly isolates focus management from stack/listener management with no regressions.

The effect split is logically sound: the focus-lifecycle effect has exactly the right dependency (isModalOpen only), the hasFocusedOnOpen guard is no longer needed and its removal is correct, and the focus-timer is cancelled before focus is restored in every cleanup path. The stack/keydown effect remains idempotent across re-runs. No accessibility contract is broken.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| projojo_frontend/src/components/Modal.jsx | Effect split is logically correct; hasFocusedOnOpen removal is safe; focus-timer cancellation and focus restoration on unmount are both handled. No new bugs introduced. |

</details>

<sub>Reviews (2): Last reviewed commit: ["updated comments after PR review"](https://github.com/han-aim-cmd-wg/projojo/commit/0b71b0b31149e81b81cb86f3289560f3ee02da6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45924664)</sub>

<!-- /greptile_comment -->