### PR TITLE
Fix layout, color and a11y bugs

### DIFF
--- a/projojo_frontend/src/components/DiscoverySection.jsx
+++ b/projojo_frontend/src/components/DiscoverySection.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { getPublicProjects, getThemes, IMAGE_BASE_URL } from '../services';
 import PublicProjectCard from './PublicProjectCard';
 import SkeletonList from './SkeletonList';
+import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
 
 /**
  * DiscoverySection Component
@@ -176,13 +177,15 @@ export default function DiscoverySection() {
                         </div>
                     </div>
 
-                    {/* Theme pills - horizontal scroll */}
+                    {/* Theme pills - wraps so no pill is ever sliced off at the card edge */}
                     {themes.length > 0 && (
-                        <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none mt-3 pt-3 border-t border-[var(--neu-border)] -mx-1 px-1">
+                        <div className="flex flex-wrap items-center gap-1.5 mt-3 pt-3 border-t border-[var(--neu-border)]">
                             <span className="neu-label shrink-0 mr-0.5">Thema&apos;s</span>
                             <button
+                                type="button"
+                                aria-pressed={!selectedTheme}
                                 onClick={() => setSelectedTheme(null)}
-                                className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${!selectedTheme
+                                className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${!selectedTheme
                                         ? 'bg-primary text-white'
                                         : 'text-[var(--text-muted)] hover:text-primary'
                                     }`}
@@ -192,15 +195,18 @@ export default function DiscoverySection() {
                             {themes.map(theme => {
                                 const count = projects.filter(p => p.themes?.some(t => t.id === theme.id)).length;
                                 if (count === 0) return null;
+                                const isSelected = selectedTheme === theme.id;
                                 return (
                                     <button
                                         key={theme.id}
-                                        onClick={() => setSelectedTheme(selectedTheme === theme.id ? null : theme.id)}
-                                        className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${selectedTheme === theme.id
-                                                ? 'text-white'
+                                        type="button"
+                                        aria-pressed={isSelected}
+                                        onClick={() => setSelectedTheme(isSelected ? null : theme.id)}
+                                        className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${isSelected
+                                                ? ''
                                                 : 'text-[var(--text-secondary)] hover:text-primary'
                                             }`}
-                                        style={selectedTheme === theme.id && theme.color ? { backgroundColor: theme.color } : {}}
+                                        style={isSelected ? legibleFill(theme.color || COLORLESS_THEME_FILL) : undefined}
                                     >
                                         {theme.icon && (
                                             <span className="material-symbols-outlined text-[11px]" aria-hidden="true">{theme.icon}</span>
@@ -213,13 +219,15 @@ export default function DiscoverySection() {
                         </div>
                     )}
 
-                    {/* Location filter - horizontal scroll */}
+                    {/* Location filter - wraps, same reason as the theme row above */}
                     {locations.length > 0 && (
-                        <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none mt-2 -mx-1 px-1">
+                        <div className="flex flex-wrap items-center gap-1.5 mt-2">
                             <span className="material-symbols-outlined text-xs text-[var(--text-muted)] shrink-0" aria-hidden="true">location_on</span>
                             <button
+                                type="button"
+                                aria-pressed={!selectedLocation}
                                 onClick={() => setSelectedLocation('')}
-                                className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${!selectedLocation
+                                className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${!selectedLocation
                                         ? 'bg-primary text-white'
                                         : 'text-[var(--text-muted)] hover:text-primary'
                                     }`}
@@ -229,8 +237,10 @@ export default function DiscoverySection() {
                             {locations.map(loc => (
                                 <button
                                     key={loc}
+                                    type="button"
+                                    aria-pressed={selectedLocation === loc}
                                     onClick={() => setSelectedLocation(selectedLocation === loc ? '' : loc)}
-                                    className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${selectedLocation === loc
+                                    className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all cursor-pointer ${selectedLocation === loc
                                             ? 'bg-primary text-white'
                                             : 'text-[var(--text-muted)] hover:text-primary'
                                         }`}

--- a/projojo_frontend/src/components/Filter.jsx
+++ b/projojo_frontend/src/components/Filter.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useRef } from "react";
 import { getSkills } from '../services';
 import { normalizeSkill } from '../utils/skills';
+import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
 import { useStudentSkills } from '../context/StudentSkillsContext';
 import { useStudentWork } from '../context/StudentWorkContext';
 import Alert from "./Alert";
@@ -439,13 +440,18 @@ export default function Filter({ onFilter, businesses = [], themes = [], allBusi
                     </span>
                 </div>
 
-                {/* === Theme pills === */}
+                {/* === Theme pills ===
+                    The row wraps instead of scrolling horizontally: a hidden-scrollbar row
+                    sliced the last pill mid-word with nothing to hint at the overflow, and
+                    an overflow-x scroll box also clips the focus ring vertically. */}
                 {themes.length > 0 && (
-                    <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none pb-0.5 -mx-1 px-1 mb-1">
+                    <div className="flex flex-wrap items-center gap-1.5 mb-1">
                         <span className="neu-label shrink-0 mr-0.5">Thema&apos;s</span>
                         <button
+                            type="button"
+                            aria-pressed={!selectedTheme}
                             onClick={() => { setSelectedTheme(null); triggerFilter({ selectedTheme: null }); }}
-                            className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedTheme ? 'bg-primary text-white' : 'text-[var(--text-muted)] hover:text-primary'
+                            className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedTheme ? 'bg-primary text-white' : 'text-[var(--text-muted)] hover:text-primary'
                                 }`}
                         >
                             Alles
@@ -453,17 +459,20 @@ export default function Filter({ onFilter, businesses = [], themes = [], allBusi
                         {themes.map(theme => {
                             const count = themeCounts[theme.id] || 0;
                             if (count === 0) return null;
+                            const isSelected = selectedTheme === theme.id;
                             return (
                                 <button
                                     key={theme.id}
+                                    type="button"
+                                    aria-pressed={isSelected}
                                     onClick={() => {
-                                        const val = selectedTheme === theme.id ? null : theme.id;
+                                        const val = isSelected ? null : theme.id;
                                         setSelectedTheme(val);
                                         triggerFilter({ selectedTheme: val });
                                     }}
-                                    className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${selectedTheme === theme.id ? 'text-white' : 'text-[var(--text-secondary)] hover:text-primary'
+                                    className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${isSelected ? '' : 'text-[var(--text-secondary)] hover:text-primary'
                                         }`}
-                                    style={selectedTheme === theme.id && theme.color ? { backgroundColor: theme.color } : {}}
+                                    style={isSelected ? legibleFill(theme.color || COLORLESS_THEME_FILL) : undefined}
                                 >
                                     {theme.icon && <span className="material-symbols-outlined text-[11px]" aria-hidden="true">{theme.icon}</span>}
                                     {theme.name}
@@ -476,26 +485,31 @@ export default function Filter({ onFilter, businesses = [], themes = [], allBusi
 
                 {/* === Sector pills === */}
                 {filterOptions.sectors.length > 0 && (
-                    <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none pb-0.5 -mx-1 px-1 mb-1">
+                    <div className="flex flex-wrap items-center gap-1.5 mb-1">
                         <span className="neu-label shrink-0 mr-0.5">Sector</span>
                         <button
+                            type="button"
+                            aria-pressed={!selectedSector}
                             onClick={() => { setSelectedSector(null); triggerFilter({ sector: null }); }}
-                            className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedSector ? 'bg-primary text-white' : 'text-[var(--text-muted)] hover:text-primary'
+                            className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedSector ? 'bg-primary text-white' : 'text-[var(--text-muted)] hover:text-primary'
                                 }`}
                         >
                             Alles
                         </button>
                         {filterOptions.sectors.map(sector => {
                             const count = filterOptions.sectorCounts[sector] || 0;
+                            const isSelected = selectedSector === sector;
                             return (
                                 <button
                                     key={sector}
+                                    type="button"
+                                    aria-pressed={isSelected}
                                     onClick={() => {
-                                        const val = selectedSector === sector ? null : sector;
+                                        const val = isSelected ? null : sector;
                                         setSelectedSector(val);
                                         triggerFilter({ sector: val });
                                     }}
-                                    className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${selectedSector === sector
+                                    className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${isSelected
                                             ? 'bg-[var(--text-primary)] text-white'
                                             : 'text-[var(--text-secondary)] hover:text-primary'
                                         }`}

--- a/projojo_frontend/src/pages/PublicDiscoveryPage.jsx
+++ b/projojo_frontend/src/pages/PublicDiscoveryPage.jsx
@@ -8,6 +8,7 @@ import RichTextViewer from '../components/RichTextViewer';
 import LocationMap from '../components/LocationMap';
 import OverviewMap from '../components/OverviewMap';
 import { formatDate } from '../utils/dates';
+import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
 
 /**
  * PublicDiscoveryPage
@@ -272,13 +273,15 @@ function PublicProjectList() {
                         </div>
                     </div>
 
-                    {/* Theme pills - compact single row with overflow */}
+                    {/* Theme pills - wraps so no pill is ever sliced off at the card edge */}
                     {themes.length > 0 && (
-                        <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-none pt-1 pb-1 -mx-1 px-1">
+                        <div className="flex flex-wrap items-center gap-1.5 pt-1 pb-1">
                             <span className="neu-label shrink-0 mr-0.5">Thema&apos;s</span>
                             <button
+                                type="button"
+                                aria-pressed={!selectedTheme}
                                 onClick={() => setSelectedTheme(null)}
-                                className={`shrink-0 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedTheme
+                                className={`px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${!selectedTheme
                                         ? 'bg-primary text-white'
                                         : 'text-[var(--text-muted)] hover:text-primary'
                                     }`}
@@ -288,15 +291,18 @@ function PublicProjectList() {
                             {themes.map(theme => {
                                 const count = projects.filter(p => p.themes?.some(t => t.id === theme.id)).length;
                                 if (count === 0) return null;
+                                const isSelected = selectedTheme === theme.id;
                                 return (
                                     <button
                                         key={theme.id}
-                                        onClick={() => setSelectedTheme(selectedTheme === theme.id ? null : theme.id)}
-                                        className={`shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${selectedTheme === theme.id
-                                                ? 'text-white'
+                                        type="button"
+                                        aria-pressed={isSelected}
+                                        onClick={() => setSelectedTheme(isSelected ? null : theme.id)}
+                                        className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold transition-all duration-200 cursor-pointer ${isSelected
+                                                ? ''
                                                 : 'text-[var(--text-secondary)] hover:text-primary'
                                             }`}
-                                        style={selectedTheme === theme.id && theme.color ? { backgroundColor: theme.color } : {}}
+                                        style={isSelected ? legibleFill(theme.color || COLORLESS_THEME_FILL) : undefined}
                                     >
                                         {theme.icon && (
                                             <span className="material-symbols-outlined text-[11px]" aria-hidden="true">{theme.icon}</span>

--- a/projojo_frontend/src/pages/SupervisorDashboard.jsx
+++ b/projojo_frontend/src/pages/SupervisorDashboard.jsx
@@ -110,9 +110,9 @@ export default function SupervisorDashboard() {
             {isLoading ? (
                 <Loading />
             ) : (
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
                     {/* Main content */}
-                    <div className="lg:col-span-2 space-y-6">
+                    <div className="xl:col-span-2 space-y-6">
                         {/* Pending Registrations Section */}
                         <section className="neu-flat p-6">
                             <div className="flex items-center justify-between mb-5">
@@ -220,8 +220,9 @@ export default function SupervisorDashboard() {
                         </section>
                     </div>
 
-                    {/* Sidebar */}
-                    <div className="space-y-6">
+                    {/* Sidebar - a row of cards under the main column until xl, where it
+                        becomes the actual right-hand sidebar */}
+                    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-1 xl:content-start">
                         {/* Quick Stats */}
                         <section className="neu-flat p-5">
                             <h3 className="text-sm font-bold text-[var(--text-secondary)] uppercase tracking-wide mb-4">

--- a/projojo_frontend/src/pages/SupervisorDashboard.jsx
+++ b/projojo_frontend/src/pages/SupervisorDashboard.jsx
@@ -66,12 +66,12 @@ export default function SupervisorDashboard() {
                 </div>
                 
                 <div className="neu-flat p-8 text-center">
-                    <span className="material-symbols-outlined text-4xl text-gray-400 mb-3">business</span>
+                    <span className="material-symbols-outlined text-4xl text-gray-400 mb-3" aria-hidden="true">business</span>
                     <p className="text-[var(--text-secondary)] font-medium">
                         Dit dashboard is alleen beschikbaar voor supervisors.
                     </p>
                     <Link to="/ontdek" className="neu-btn-primary mt-4 inline-flex items-center gap-2">
-                        <span className="material-symbols-outlined">explore</span>
+                        <span className="material-symbols-outlined" aria-hidden="true">explore</span>
                         Ontdek projecten
                     </Link>
                 </div>
@@ -100,7 +100,7 @@ export default function SupervisorDashboard() {
             {/* Quick Actions */}
             <div className="flex flex-wrap gap-3">
                 <Link to="/projects/add" className="neu-btn-primary inline-flex items-center gap-2">
-                    <span className="material-symbols-outlined">add</span>
+                    <span className="material-symbols-outlined" aria-hidden="true">add</span>
                     Nieuw Project
                 </Link>
             </div>
@@ -117,7 +117,7 @@ export default function SupervisorDashboard() {
                         <section className="neu-flat p-6">
                             <div className="flex items-center justify-between mb-5">
                                 <h2 className="flex items-center gap-2 text-lg font-bold text-[var(--text-primary)]">
-                                    <span className="material-symbols-outlined text-primary">pending_actions</span>
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">pending_actions</span>
                                     Openstaande Aanmeldingen
                                 </h2>
                                 {dashboardData?.pending_registrations?.length > 0 && (
@@ -127,7 +127,7 @@ export default function SupervisorDashboard() {
 
                             {(!dashboardData?.pending_registrations || dashboardData.pending_registrations.length === 0) ? (
                                 <div className="neu-pressed p-6 text-center">
-                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2">inbox</span>
+                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2" aria-hidden="true">inbox</span>
                                     <p className="text-[var(--text-muted)] text-sm">
                                         Geen openstaande aanmeldingen
                                     </p>
@@ -149,7 +149,7 @@ export default function SupervisorDashboard() {
                         <section className="neu-flat p-6">
                             <div className="flex items-center justify-between mb-5">
                                 <h2 className="flex items-center gap-2 text-lg font-bold text-[var(--text-primary)]">
-                                    <span className="material-symbols-outlined text-primary">folder</span>
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">folder</span>
                                     Mijn Projecten
                                 </h2>
                                 {dashboardData?.projects?.length > 0 && (
@@ -159,12 +159,12 @@ export default function SupervisorDashboard() {
 
                             {(!dashboardData?.projects || dashboardData.projects.length === 0) ? (
                                 <div className="neu-pressed p-6 text-center">
-                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2">folder_off</span>
+                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2" aria-hidden="true">folder_off</span>
                                     <p className="text-[var(--text-muted)] text-sm mb-4">
                                         Nog geen projecten aangemaakt
                                     </p>
                                     <Link to="/projects/add" className="neu-btn-primary inline-flex items-center gap-2">
-                                        <span className="material-symbols-outlined">add</span>
+                                        <span className="material-symbols-outlined" aria-hidden="true">add</span>
                                         Maak je eerste project
                                     </Link>
                                 </div>
@@ -192,7 +192,7 @@ export default function SupervisorDashboard() {
                         <section className="neu-flat p-6">
                             <div className="flex items-center justify-between mb-5">
                                 <h2 className="flex items-center gap-2 text-lg font-bold text-[var(--text-primary)]">
-                                    <span className="material-symbols-outlined text-green-500">group</span>
+                                    <span className="material-symbols-outlined text-green-500" aria-hidden="true">group</span>
                                     Actieve Studenten
                                 </h2>
                                 {dashboardData?.active_students?.length > 0 && (
@@ -202,7 +202,7 @@ export default function SupervisorDashboard() {
 
                             {(!dashboardData?.active_students || dashboardData.active_students.length === 0) ? (
                                 <div className="neu-pressed p-6 text-center">
-                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2">person_off</span>
+                                    <span className="material-symbols-outlined text-3xl text-gray-300 mb-2" aria-hidden="true">person_off</span>
                                     <p className="text-[var(--text-muted)] text-sm">
                                         Nog geen actieve studenten
                                     </p>
@@ -263,15 +263,15 @@ export default function SupervisorDashboard() {
                             </h3>
                             <div className="space-y-2">
                                 <Link to="/projects/add" className="neu-btn w-full justify-start gap-3 !text-sm">
-                                    <span className="material-symbols-outlined text-primary">add_box</span>
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">add_box</span>
                                     Nieuw project
                                 </Link>
                                 <Link to={`/business/${dashboardData?.business_id}`} className="neu-btn w-full justify-start gap-3 !text-sm">
-                                    <span className="material-symbols-outlined text-primary">business</span>
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">business</span>
                                     Organisatiepagina
                                 </Link>
                                 <Link to="/ontdek" className="neu-btn w-full justify-start gap-3 !text-sm">
-                                    <span className="material-symbols-outlined text-primary">explore</span>
+                                    <span className="material-symbols-outlined text-primary" aria-hidden="true">explore</span>
                                     Ontdek platform
                                 </Link>
                             </div>
@@ -280,7 +280,7 @@ export default function SupervisorDashboard() {
                         {/* Tips section */}
                         <section className="neu-pressed p-5">
                             <div className="flex items-start gap-3">
-                                <span className="material-symbols-outlined text-primary">lightbulb</span>
+                                <span className="material-symbols-outlined text-primary" aria-hidden="true">lightbulb</span>
                                 <div>
                                     <h4 className="font-bold text-[var(--text-primary)] text-sm">Tip</h4>
                                     <p className="text-xs text-[var(--text-muted)] mt-1">
@@ -385,7 +385,7 @@ function RegistrationCard({ registration, onUpdate }) {
                 <div className="flex-1 lg:border-l lg:border-r lg:border-gray-100 lg:px-5">
                     <div className="neu-pressed p-4 rounded-lg">
                         <div className="flex items-start gap-3 mb-3">
-                            <span className="material-symbols-outlined text-primary text-lg">task</span>
+                            <span className="material-symbols-outlined text-primary text-lg" aria-hidden="true">task</span>
                             <div>
                                 <p className="text-xs text-[var(--text-muted)] uppercase tracking-wide">Taak</p>
                                 <Link 
@@ -397,7 +397,7 @@ function RegistrationCard({ registration, onUpdate }) {
                             </div>
                         </div>
                         <div className="flex items-start gap-3">
-                            <span className="material-symbols-outlined text-gray-400 text-lg">folder</span>
+                            <span className="material-symbols-outlined text-gray-400 text-lg" aria-hidden="true">folder</span>
                             <div>
                                 <p className="text-xs text-[var(--text-muted)] uppercase tracking-wide">Project</p>
                                 <p className="font-semibold text-[var(--text-secondary)]">{registration.project_name}</p>
@@ -421,7 +421,7 @@ function RegistrationCard({ registration, onUpdate }) {
                     {/* Error message */}
                     {localError && (
                         <p className="text-xs text-red-500 mb-2 flex items-center gap-1">
-                            <span className="material-symbols-outlined text-sm">error</span>
+                            <span className="material-symbols-outlined text-sm" aria-hidden="true">error</span>
                             {localError}
                         </p>
                     )}
@@ -464,14 +464,14 @@ function RegistrationCard({ registration, onUpdate }) {
                                 onClick={() => handleAction('accept')}
                                 className="neu-btn-primary flex-1"
                             >
-                                <span className="material-symbols-outlined text-sm mr-1.5">check</span>
+                                <span className="material-symbols-outlined text-sm mr-1.5" aria-hidden="true">check</span>
                                 Accepteren
                             </button>
                             <button
                                 onClick={() => handleAction('reject')}
                                 className="neu-btn flex-1 !text-red-500 hover:!bg-red-50"
                             >
-                                <span className="material-symbols-outlined text-sm mr-1.5">close</span>
+                                <span className="material-symbols-outlined text-sm mr-1.5" aria-hidden="true">close</span>
                                 Afwijzen
                             </button>
                         </div>
@@ -512,14 +512,14 @@ function ActiveStudentCard({ student }) {
             {/* Project & Task info */}
             <div className="neu-pressed p-3 rounded-lg space-y-2">
                 <div className="flex items-start gap-2">
-                    <span className="material-symbols-outlined text-gray-400 text-sm mt-0.5">folder</span>
+                    <span className="material-symbols-outlined text-gray-400 text-sm mt-0.5" aria-hidden="true">folder</span>
                     <div>
                         <p className="text-xs text-[var(--text-muted)] uppercase tracking-wide">Project</p>
                         <p className="text-sm font-semibold text-[var(--text-primary)]">{student.project_name}</p>
                     </div>
                 </div>
                 <div className="flex items-start gap-2">
-                    <span className="material-symbols-outlined text-primary text-sm mt-0.5">task</span>
+                    <span className="material-symbols-outlined text-primary text-sm mt-0.5" aria-hidden="true">task</span>
                     <div>
                         <p className="text-xs text-[var(--text-muted)] uppercase tracking-wide">Taak</p>
                         <p className="text-sm font-semibold text-[var(--text-primary)]">{student.task_name}</p>
@@ -530,7 +530,7 @@ function ActiveStudentCard({ student }) {
             {/* Footer */}
             <div className="flex items-center justify-end mt-3 text-xs text-primary font-medium">
                 Bekijk profiel
-                <span className="material-symbols-outlined text-sm ml-1">arrow_forward</span>
+                <span className="material-symbols-outlined text-sm ml-1" aria-hidden="true">arrow_forward</span>
             </div>
         </Link>
     );
@@ -567,8 +567,14 @@ function ProjectCard({ project, pendingCount = 0 }) {
                     {/* Pending badge overlay */}
                     {pendingCount > 0 && (
                         <span className="absolute top-1.5 left-1.5 bg-primary text-white text-xs font-bold px-1.5 py-0.5 rounded-full flex items-center gap-0.5">
-                            <span className="material-symbols-outlined text-xs">person_add</span>
+                            <span className="material-symbols-outlined text-xs" aria-hidden="true">person_add</span>
                             {pendingCount}
+                            {/* The icon is what gives the bare count its meaning on screen, so
+                                hiding it from assistive tech would leave the card link's
+                                accessible name reading just a number. Name it in text instead. */}
+                            <span className="sr-only">
+                                {pendingCount === 1 ? 'openstaande aanmelding' : 'openstaande aanmeldingen'}
+                            </span>
                         </span>
                     )}
                 </div>
@@ -581,12 +587,12 @@ function ProjectCard({ project, pendingCount = 0 }) {
                         </h4>
                         <div className="flex items-center gap-3 mt-1.5">
                             <span className="inline-flex items-center gap-1 text-xs text-[var(--text-muted)]">
-                                <span className="material-symbols-outlined text-sm">task</span>
+                                <span className="material-symbols-outlined text-sm" aria-hidden="true">task</span>
                                 {taskCount} {taskCount === 1 ? 'taak' : 'taken'}
                             </span>
                             {pendingCount > 0 && (
                                 <span className="inline-flex items-center gap-1 text-xs text-primary font-medium">
-                                    <span className="material-symbols-outlined text-sm">notifications</span>
+                                    <span className="material-symbols-outlined text-sm" aria-hidden="true">notifications</span>
                                     Actie
                                 </span>
                             )}
@@ -636,7 +642,10 @@ function ProjectCard({ project, pendingCount = 0 }) {
                         )}
 
                         {/* Arrow indicator */}
-                        <span className="material-symbols-outlined text-base text-[var(--text-muted)] group-hover:text-primary transition-colors ml-auto shrink-0">
+                        <span
+                            className="material-symbols-outlined text-base text-[var(--text-muted)] group-hover:text-primary transition-colors ml-auto shrink-0"
+                            aria-hidden="true"
+                        >
                             arrow_forward
                         </span>
                     </div>
@@ -653,7 +662,7 @@ function StatItem({ icon, label, value, color }) {
     return (
         <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-                <span className={`material-symbols-outlined text-lg ${color}`}>{icon}</span>
+                <span className={`material-symbols-outlined text-lg ${color}`} aria-hidden="true">{icon}</span>
                 <span className="text-sm text-[var(--text-secondary)]">{label}</span>
             </div>
             <span className="font-bold text-[var(--text-primary)]">{value}</span>

--- a/tests/e2e/steps/ts-task-021-supervisor-dashboard-themes.steps.cjs
+++ b/tests/e2e/steps/ts-task-021-supervisor-dashboard-themes.steps.cjs
@@ -163,8 +163,10 @@ async function shownPillNames(world) {
  * Filtered on the heading element rather than on `hasText`: that option matches any
  * descendant text case-insensitively, so "Actieve Studenten" would also select the
  * sidebar's Statistieken section, which carries an "Actieve studenten" stat row.
- * The heading name is matched as a substring because each of these headings also
- * contains a Material Symbols ligature that folds into its accessible name.
+ * The heading name is matched as a substring, which is `getByRole`'s default: each of
+ * these headings also renders a Material Symbols glyph, and while that glyph is now
+ * `aria-hidden` and so stays out of the computed name, the substring match does not
+ * depend on it either way.
  */
 function sectionTitled(world, heading) {
   return page(world)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves responsive filter and dashboard layouts while correcting theme-pill contrast and decorative-icon accessibility.
- Replaces horizontally clipped filter rows with wrapping layouts.
- Adds pressed-state semantics and legible selected-theme colors.
- Refines the supervisor dashboard’s responsive grid, compact theme summaries, and accessible icon treatment.
- Updates dashboard end-to-end helpers for the revised accessible markup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The responsive layout, contrast-aware theme styling, pressed-state metadata, and decorative-icon changes preserve existing data and interaction contracts while addressing the intended visual and accessibility defects.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| projojo_frontend/src/components/DiscoverySection.jsx | Theme and location filters now wrap, expose pressed state, and use contrast-aware selected-theme colors without changing filtering behavior. |
| projojo_frontend/src/components/Filter.jsx | Theme and sector pills receive responsive wrapping, pressed-state semantics, and established contrast-aware theme styling. |
| projojo_frontend/src/pages/PublicDiscoveryPage.jsx | Public discovery theme filters adopt the same wrapping, accessibility, and selected-color behavior as the other discovery surfaces. |
| projojo_frontend/src/pages/SupervisorDashboard.jsx | The dashboard gains a later sidebar breakpoint, responsive sidebar cards, compact project theme pills, and decorative-icon accessibility fixes. |
| tests/e2e/steps/ts-task-021-supervisor-dashboard-themes.steps.cjs | End-to-end locator documentation is aligned with decorative icons being removed from accessible heading names. |

</details>

<sub>Reviews (1): Last reviewed commit: ["a11y: added aria hidden to icons"](https://github.com/han-aim-cmd-wg/projojo/commit/63daec8dd1edeb5ab2c4b41f977da9f9cec5310c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50487064)</sub>

<!-- /greptile_comment -->