### PR TITLE
Next UI ts story 004

### DIFF
--- a/projojo_backend/domain/repositories/business_repository.py
+++ b/projojo_backend/domain/repositories/business_repository.py
@@ -279,8 +279,10 @@ class BusinessRepository(BaseRepository[Business]):
             ]
 
         # TypeDB returns optional attributes as lists. Flatten the nested theme
-        # icon/color/sdg_code so a project's themes here are field-for-field identical
-        # to GET /themes/project/{id}, matching get_public_projects().
+        # icon/color/sdg_code so a project's themes here carry the fields the theme
+        # surfaces read (id/name/icon/color/sdg_code), matching get_public_projects().
+        # This route declares no response_model, so the wire shape is this 5-key dict,
+        # not the full Theme model GET /themes/project/{id} returns.
         for business in results:
             for project in business.get("projects", []):
                 project["themes"] = [

--- a/projojo_backend/domain/repositories/business_repository.py
+++ b/projojo_backend/domain/repositories/business_repository.py
@@ -211,7 +211,8 @@ class BusinessRepository(BaseRepository[Business]):
                             "id": $theme_id,
                             "name": $theme_name,
                             "icon": [$theme.icon],
-                            "color": [$theme.color]
+                            "color": [$theme.color],
+                            "sdg_code": [$theme.sdgCode]
                         };
                     ],
                     "tasks": [
@@ -278,8 +279,8 @@ class BusinessRepository(BaseRepository[Business]):
             ]
 
         # TypeDB returns optional attributes as lists. Flatten the nested theme
-        # icon/color so a project's themes here are field-for-field identical to
-        # GET /themes/project/{id}, matching get_public_projects().
+        # icon/color/sdg_code so a project's themes here are field-for-field identical
+        # to GET /themes/project/{id}, matching get_public_projects().
         for business in results:
             for project in business.get("projects", []):
                 project["themes"] = [
@@ -288,6 +289,7 @@ class BusinessRepository(BaseRepository[Business]):
                         "name": theme.get("name", ""),
                         "icon": (theme.get("icon") or [None])[0],
                         "color": (theme.get("color") or [None])[0],
+                        "sdg_code": (theme.get("sdg_code") or [None])[0],
                     }
                     for theme in project.get("themes", [])
                 ]

--- a/projojo_backend/domain/repositories/project_repository.py
+++ b/projojo_backend/domain/repositories/project_repository.py
@@ -108,7 +108,8 @@ class ProjectRepository(BaseRepository[Project]):
                         'id': $theme_id,
                         'name': $theme_name,
                         'icon': [$theme.icon],
-                        'color': [$theme.color]
+                        'color': [$theme.color],
+                        'sdg_code': [$theme.sdgCode]
                     };
                 ],
                 'tasks': [
@@ -164,11 +165,13 @@ class ProjectRepository(BaseRepository[Project]):
             for t in themes_data:
                 icon_list = t.get("icon", [])
                 color_list = t.get("color", [])
+                sdg_code_list = t.get("sdg_code", [])
                 themes.append({
                     "id": t.get("id", ""),
                     "name": t.get("name", ""),
                     "icon": icon_list[0] if icon_list else None,
-                    "color": color_list[0] if color_list else None
+                    "color": color_list[0] if color_list else None,
+                    "sdg_code": sdg_code_list[0] if sdg_code_list else None
                 })
             
             public_projects.append({
@@ -268,7 +271,8 @@ class ProjectRepository(BaseRepository[Project]):
                         'id': $theme_id,
                         'name': $theme_name,
                         'icon': [$theme.icon],
-                        'color': [$theme.color]
+                        'color': [$theme.color],
+                        'sdg_code': [$theme.sdgCode]
                     };
                 ],
                 'tasks': [
@@ -356,8 +360,8 @@ class ProjectRepository(BaseRepository[Project]):
             ]
 
         # Map themes if the query fetched them. TypeDB returns optional attributes
-        # as lists, so icon and color are flattened the same way the nested themes
-        # of get_all_with_full_nesting() and get_public_projects() are.
+        # as lists, so icon, color and sdg_code are flattened the same way the nested
+        # themes of get_all_with_full_nesting() and get_public_projects() are.
         themes_data = result.get("themes")
         themes = None
         if themes_data is not None:
@@ -368,6 +372,7 @@ class ProjectRepository(BaseRepository[Project]):
                     name=t.get("name", ""),
                     icon=(t.get("icon") or [None])[0],
                     color=(t.get("color") or [None])[0],
+                    sdg_code=(t.get("sdg_code") or [None])[0],
                 )
                 for t in themes_data
             ]

--- a/projojo_frontend/src/components/ProjectThemeBadge.jsx
+++ b/projojo_frontend/src/components/ProjectThemeBadge.jsx
@@ -58,10 +58,14 @@ export default function ProjectThemeBadge({ themes }) {
                         {theme.icon}
                     </span>
                 )}
-                <span data-testid="project-theme-badge-name">{theme.name}</span>
+                {/* Cap the name (ch-based, so it bites only on genuinely long teacher-authored
+                    names) so a long name plus the SDG badges can't run the row across the
+                    opposite-corner status badge. innerText keeps the full name for the tests. */}
+                <span data-testid="project-theme-badge-name" className="max-w-[20ch] truncate">{theme.name}</span>
                 {hiddenThemeCount > 0 && (
                     <span
                         data-testid="project-theme-badge-overflow"
+                        role="img"
                         title={`nog ${hiddenThemeCount} thema${hiddenThemeCount === 1 ? '' : "'s"}`}
                         aria-label={`nog ${hiddenThemeCount} thema${hiddenThemeCount === 1 ? '' : "'s"}`}
                         className="opacity-70"
@@ -77,9 +81,12 @@ export default function ProjectThemeBadge({ themes }) {
                 // composites to at worst ~5.7:1 (over pure white) - clear of WCAG AA 4.5:1 for
                 // any project photo. Kept smaller and square-ish so it reads as a counter rather
                 // than a third goal, and labelled in Dutch so a screen reader hears
-                // "nog 15 SDG-doelen" rather than a bare "+15".
+                // "nog 15 SDG-doelen" rather than a bare "+15". role="img" makes it a named leaf
+                // so that aria-label is actually exposed (bare <span> is role=generic, which
+                // prohibits the attribute) - the same reason the passive SdgBadge sibling uses it.
                 <span
                     data-testid="sdg-badge-overflow"
+                    role="img"
                     title={`nog ${hiddenSdgCount} SDG-${hiddenSdgCount === 1 ? 'doel' : 'doelen'}`}
                     aria-label={`nog ${hiddenSdgCount} SDG-${hiddenSdgCount === 1 ? 'doel' : 'doelen'}`}
                     className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-md text-[9px] font-bold bg-black/60 text-white ring-1 ring-white/40"

--- a/projojo_frontend/src/components/ProjectThemeBadge.jsx
+++ b/projojo_frontend/src/components/ProjectThemeBadge.jsx
@@ -1,5 +1,5 @@
 import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
-import { parseSdgCodes } from '../utils/sdg';
+import { parseSdgGoals } from '../utils/sdg';
 import SdgBadge from './SdgBadge';
 
 // How many SDG badges the cramped card shows before collapsing the rest into "+N".
@@ -18,9 +18,9 @@ const CARD_SDG_BADGE_LIMIT = 2;
  * would make that choice depend on the project photo behind the badge.
  *
  * The primary theme's SDG badge sits beside the pill as a PASSIVE indicator
- * (`interactive={false}`): colour and hover/focus tooltip only, no link. The whole
+ * (`interactive={false}`): colour plus a native `title` on hover, no link. The whole
  * card is a single <Link>, so a nested <a> here would be invalid HTML - AC-5 of
- * TS-task-023 allows exactly this tooltip-only form when space is tight.
+ * TS-task-023 allows exactly this hover-only form when space is tight.
  *
  * Shared by PublicProjectCard and the authenticated ProjectCard so both surfaces
  * stay visually identical. Positioning is left to the card, since the two place
@@ -35,9 +35,15 @@ export default function ProjectThemeBadge({ themes }) {
     // status/archived badge in the opposite corner, so drawing a badge per goal would run
     // the row straight across that badge. This mirrors how the card already reduces "many
     // themes" to one pill plus "+N"; the full SDG set stays on the project details page.
-    const sdgCodes = parseSdgCodes(theme.sdg_code);
-    const shownSdgCodes = sdgCodes.slice(0, CARD_SDG_BADGE_LIMIT);
-    const hiddenSdgCount = sdgCodes.length - shownSdgCodes.length;
+    //
+    // Counts are taken from parseSdgGoals - the deduped, valid-only list SdgBadge itself
+    // renders - so the badge count and the "+N" count can never disagree. A repeated code
+    // (e.g. "SDG12,SDG12", still accepted by the backend until TS-task-028) is one goal,
+    // one badge, and is not miscounted into the overflow.
+    const goals = parseSdgGoals(theme.sdg_code);
+    const shownSdgCodes = goals.slice(0, CARD_SDG_BADGE_LIMIT).map((goal) => `SDG${goal.number}`);
+    const hiddenSdgCount = goals.length - shownSdgCodes.length;
+    const hiddenThemeCount = themes.length - 1;
 
     return (
         <span className="inline-flex items-center gap-1">
@@ -53,15 +59,30 @@ export default function ProjectThemeBadge({ themes }) {
                     </span>
                 )}
                 <span data-testid="project-theme-badge-name">{theme.name}</span>
-                {themes.length > 1 && (
-                    <span data-testid="project-theme-badge-overflow" className="opacity-70">+{themes.length - 1}</span>
+                {hiddenThemeCount > 0 && (
+                    <span
+                        data-testid="project-theme-badge-overflow"
+                        title={`nog ${hiddenThemeCount} thema${hiddenThemeCount === 1 ? '' : "'s"}`}
+                        aria-label={`nog ${hiddenThemeCount} thema${hiddenThemeCount === 1 ? '' : "'s"}`}
+                        className="opacity-70"
+                    >
+                        +{hiddenThemeCount}
+                    </span>
                 )}
             </span>
             <SdgBadge sdgCode={shownSdgCodes.join(',')} interactive={false} />
             {hiddenSdgCount > 0 && (
+                // A translucent dark fill is safe here, unlike the goal badges whose fill must
+                // be opaque: black at 60% can only ever darken what is behind it, so white text
+                // composites to at worst ~5.7:1 (over pure white) - clear of WCAG AA 4.5:1 for
+                // any project photo. Kept smaller and square-ish so it reads as a counter rather
+                // than a third goal, and labelled in Dutch so a screen reader hears
+                // "nog 15 SDG-doelen" rather than a bare "+15".
                 <span
                     data-testid="sdg-badge-overflow"
-                    className="inline-flex items-center justify-center h-6 min-w-6 px-1 rounded-full text-[10px] font-bold bg-black/60 text-white"
+                    title={`nog ${hiddenSdgCount} SDG-${hiddenSdgCount === 1 ? 'doel' : 'doelen'}`}
+                    aria-label={`nog ${hiddenSdgCount} SDG-${hiddenSdgCount === 1 ? 'doel' : 'doelen'}`}
+                    className="inline-flex items-center justify-center h-5 min-w-5 px-1 rounded-md text-[9px] font-bold bg-black/60 text-white ring-1 ring-white/40"
                 >
                     +{hiddenSdgCount}
                 </span>

--- a/projojo_frontend/src/components/ProjectThemeBadge.jsx
+++ b/projojo_frontend/src/components/ProjectThemeBadge.jsx
@@ -1,4 +1,9 @@
 import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
+import { parseSdgCodes } from '../utils/sdg';
+import SdgBadge from './SdgBadge';
+
+// How many SDG badges the cramped card shows before collapsing the rest into "+N".
+const CARD_SDG_BADGE_LIMIT = 2;
 
 /**
  * ProjectThemeBadge Component
@@ -12,6 +17,11 @@ import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
  * so a light theme colour (white, pale yellow) stays readable. A translucent fill
  * would make that choice depend on the project photo behind the badge.
  *
+ * The primary theme's SDG badge sits beside the pill as a PASSIVE indicator
+ * (`interactive={false}`): colour and hover/focus tooltip only, no link. The whole
+ * card is a single <Link>, so a nested <a> here would be invalid HTML - AC-5 of
+ * TS-task-023 allows exactly this tooltip-only form when space is tight.
+ *
  * Shared by PublicProjectCard and the authenticated ProjectCard so both surfaces
  * stay visually identical. Positioning is left to the card, since the two place
  * the badge in different corners of their image overlay.
@@ -20,21 +30,41 @@ export default function ProjectThemeBadge({ themes }) {
     const [theme] = themes || [];
     if (!theme) return null;
 
+    // Up to CARD_SDG_BADGE_LIMIT of the primary theme's SDG goals are drawn on the card,
+    // with a "+N" count for any beyond that. The card is a cramped image overlay with a
+    // status/archived badge in the opposite corner, so drawing a badge per goal would run
+    // the row straight across that badge. This mirrors how the card already reduces "many
+    // themes" to one pill plus "+N"; the full SDG set stays on the project details page.
+    const sdgCodes = parseSdgCodes(theme.sdg_code);
+    const shownSdgCodes = sdgCodes.slice(0, CARD_SDG_BADGE_LIMIT);
+    const hiddenSdgCount = sdgCodes.length - shownSdgCodes.length;
+
     return (
-        <span
-            data-testid="project-theme-badge"
-            data-theme-id={theme.id}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold"
-            style={legibleFill(theme.color || COLORLESS_THEME_FILL)}
-        >
-            {theme.icon && (
-                <span data-testid="project-theme-badge-icon" className="material-symbols-outlined text-[10px]" aria-hidden="true">
-                    {theme.icon}
+        <span className="inline-flex items-center gap-1">
+            <span
+                data-testid="project-theme-badge"
+                data-theme-id={theme.id}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold"
+                style={legibleFill(theme.color || COLORLESS_THEME_FILL)}
+            >
+                {theme.icon && (
+                    <span data-testid="project-theme-badge-icon" className="material-symbols-outlined text-[10px]" aria-hidden="true">
+                        {theme.icon}
+                    </span>
+                )}
+                <span data-testid="project-theme-badge-name">{theme.name}</span>
+                {themes.length > 1 && (
+                    <span data-testid="project-theme-badge-overflow" className="opacity-70">+{themes.length - 1}</span>
+                )}
+            </span>
+            <SdgBadge sdgCode={shownSdgCodes.join(',')} interactive={false} />
+            {hiddenSdgCount > 0 && (
+                <span
+                    data-testid="sdg-badge-overflow"
+                    className="inline-flex items-center justify-center h-6 min-w-6 px-1 rounded-full text-[10px] font-bold bg-black/60 text-white"
+                >
+                    +{hiddenSdgCount}
                 </span>
-            )}
-            <span data-testid="project-theme-badge-name">{theme.name}</span>
-            {themes.length > 1 && (
-                <span data-testid="project-theme-badge-overflow" className="opacity-70">+{themes.length - 1}</span>
             )}
         </span>
     );

--- a/projojo_frontend/src/components/ProjectThemeSection.jsx
+++ b/projojo_frontend/src/components/ProjectThemeSection.jsx
@@ -4,6 +4,7 @@ import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
 import { sameIds } from '../utils/themeSelection';
 import ThemePicker from './ThemePicker';
 import ThemeRemovalConfirm from './ThemeRemovalConfirm';
+import SdgBadge from './SdgBadge';
 
 /**
  * ProjectThemeSection - the themes a project is linked to, with inline editing for
@@ -188,23 +189,34 @@ export default function ProjectThemeSection({ projectId, projectName, canEdit = 
                     </span>
                 ) : (
                     themes.map((theme) => (
+                        // Pill and its SDG badge as siblings. The badge is the SdgBadge
+                        // default (a link to the goal's UN page), kept ADJACENT to the pill
+                        // rather than inside it so the read-only pill stays a plain <span>
+                        // and the link is never nested in another control (TS-task-023 AC-4).
                         <span
                             key={theme.id}
-                            data-testid="project-theme-pill"
+                            data-testid="project-theme"
                             data-theme-id={theme.id}
-                            className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-bold rounded-full cursor-default"
-                            style={legibleFill(theme.color || COLORLESS_THEME_FILL)}
+                            className="inline-flex items-center gap-1.5"
                         >
-                            {theme.icon && (
-                                <span
-                                    data-testid="project-theme-icon"
-                                    className="material-symbols-outlined text-sm leading-none"
-                                    aria-hidden="true"
-                                >
-                                    {theme.icon}
-                                </span>
-                            )}
-                            <span data-testid="project-theme-name">{theme.name}</span>
+                            <span
+                                data-testid="project-theme-pill"
+                                data-theme-id={theme.id}
+                                className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-bold rounded-full cursor-default"
+                                style={legibleFill(theme.color || COLORLESS_THEME_FILL)}
+                            >
+                                {theme.icon && (
+                                    <span
+                                        data-testid="project-theme-icon"
+                                        className="material-symbols-outlined text-sm leading-none"
+                                        aria-hidden="true"
+                                    >
+                                        {theme.icon}
+                                    </span>
+                                )}
+                                <span data-testid="project-theme-name">{theme.name}</span>
+                            </span>
+                            <SdgBadge sdgCode={theme.sdg_code} />
                         </span>
                     ))
                 )}

--- a/projojo_frontend/src/components/ProjectThemeSection.jsx
+++ b/projojo_frontend/src/components/ProjectThemeSection.jsx
@@ -145,12 +145,13 @@ export default function ProjectThemeSection({ projectId, projectName, canEdit = 
         <div data-testid="project-themes" className="mt-3">
             {/* One flat flex-wrap row so the "Thema's:" label shares the first line with
                 the first pills and any overflow wraps beneath them - exactly like the
-                Skills row. role="status" makes it a polite live region so a screen reader
-                is told when the themes finish loading, come back empty, or fail - the
-                content swaps in after first paint (matches SkeletonList / ThemeManagement
-                loading regions). The editor below sits outside it: it is a deliberate
-                interaction, not a status change to announce. */}
-            <div role="status" className="flex flex-wrap items-center gap-1.5">
+                Skills row. The polite live region (role="status") sits on the transient
+                loading/empty/error messages below, NOT on this row: the loaded pills carry
+                focusable SDG goal links (TS-task-023), which must not live inside a live
+                region, and re-announcing the whole theme row on every reload would be
+                noise. A screen reader is still told when the themes are loading, come back
+                empty, or fail. The editor below is a deliberate interaction, not a status. */}
+            <div className="flex flex-wrap items-center gap-1.5">
                 <span className="text-xs font-semibold text-[var(--text-muted)] mr-1">{"Thema's:"}</span>
 
                 {canEdit && status === 'ready' && !isEditing && (
@@ -169,7 +170,7 @@ export default function ProjectThemeSection({ projectId, projectName, canEdit = 
                 )}
 
                 {isEditing ? null : status === 'loading' ? (
-                    <span data-testid="project-themes-loading" className="inline-flex items-center gap-1.5">
+                    <span data-testid="project-themes-loading" role="status" className="inline-flex items-center gap-1.5">
                         <span className="sr-only">{"Thema's laden..."}</span>
                         {[0, 1].map((i) => (
                             <span
@@ -180,11 +181,11 @@ export default function ProjectThemeSection({ projectId, projectName, canEdit = 
                         ))}
                     </span>
                 ) : status === 'error' ? (
-                    <span data-testid="project-themes-error" className="text-xs text-[var(--text-muted)]">
+                    <span data-testid="project-themes-error" role="status" className="text-xs text-[var(--text-muted)]">
                         {"Thema's konden niet worden geladen"}
                     </span>
                 ) : themes.length === 0 ? (
-                    <span data-testid="project-themes-empty" className="text-xs text-[var(--text-muted)]">
+                    <span data-testid="project-themes-empty" role="status" className="text-xs text-[var(--text-muted)]">
                         {"Geen thema's gekoppeld"}
                     </span>
                 ) : (

--- a/projojo_frontend/src/components/ProjectThemeSection.jsx
+++ b/projojo_frontend/src/components/ProjectThemeSection.jsx
@@ -149,8 +149,9 @@ export default function ProjectThemeSection({ projectId, projectName, canEdit = 
                 loading/empty/error messages below, NOT on this row: the loaded pills carry
                 focusable SDG goal links (TS-task-023), which must not live inside a live
                 region, and re-announcing the whole theme row on every reload would be
-                noise. A screen reader is still told when the themes are loading, come back
-                empty, or fail. The editor below is a deliberate interaction, not a status. */}
+                noise. A screen reader is told when the themes come back empty or fail
+                (states swapped in after first paint; the first-paint loading state itself
+                has no mutation to announce). The editor is a deliberate action, not a status. */}
             <div className="flex flex-wrap items-center gap-1.5">
                 <span className="text-xs font-semibold text-[var(--text-muted)] mr-1">{"Thema's:"}</span>
 

--- a/projojo_frontend/src/components/SdgBadge.jsx
+++ b/projojo_frontend/src/components/SdgBadge.jsx
@@ -31,10 +31,11 @@ const UN_GOAL_URL = "https://sdgs.un.org/goals/goal";
  *
  * `interactive` (default true) chooses the badge's element. Interactive renders an
  * <a href> to the goal's UN page, whose link role and focus ring are native. Passive
- * (`interactive={false}`) renders a <span role="img"> with the same fill, tooltip and
- * accessible name but no link: it is for surfaces where the badge sits inside another
- * anchor — the project cards are a single <Link>, and a nested <a> there is invalid
- * HTML — so the colour-and-tooltip indicator stands in for the goal link.
+ * (`interactive={false}`) renders a <span role="img"> with the same fill and accessible
+ * name, but a native `title` shown on hover instead of the hover-and-focus Tooltip, and
+ * no link: it is for surfaces where the badge sits inside another anchor — the project
+ * cards are a single <Link>, and a nested <a> there is invalid HTML — so the
+ * colour-and-title indicator stands in for the goal link.
  */
 export default function SdgBadge({ sdgCode, interactive = true }) {
     const goals = parseSdgGoals(sdgCode);

--- a/projojo_frontend/src/components/SdgBadge.jsx
+++ b/projojo_frontend/src/components/SdgBadge.jsx
@@ -24,7 +24,14 @@ const UN_GOAL_URL = "https://sdgs.un.org/goals/goal";
  *
  * The label colour is picked by legibleFill rather than by a fixed rule: the 17
  * official colours span very light (#FCC30B) to very dark (#19486A), and only a
- * contrast-based choice keeps every one of them readable.
+ * contrast-based choice keeps every one of them readable. Contrast is not hue
+ * consistent, so similar colours can end up with opposite labels — among the reds,
+ * SDG1 and SDG5 read black while SDG4, SDG8 and SDG10 read white. That is the
+ * choice, not a bug: every badge clears WCAG AA, which a per-hue rule would not.
+ *
+ * The link role is the native one an <a href> already carries, so no role
+ * attribute is set: spelling it out would be redundant ARIA on an element that
+ * means it natively.
  */
 export default function SdgBadge({ sdgCode }) {
     const goals = parseSdgGoals(sdgCode);
@@ -53,7 +60,9 @@ function SdgGoalBadge({ goal }) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`SDG ${goal.number}: ${goal.name}`}
-            className="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-300 transition-transform hover:scale-110"
+            // ring-offset keeps the focus ring off the fill: the primary ring against
+            // an orange goal colour (SDG9, SDG11) would otherwise barely read.
+            className="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 transition-transform hover:scale-110"
             style={legibleFill(goal.color)}
         >
             <span data-testid="sdg-badge-number" aria-hidden="true">{goal.number}</span>

--- a/projojo_frontend/src/components/SdgBadge.jsx
+++ b/projojo_frontend/src/components/SdgBadge.jsx
@@ -29,17 +29,20 @@ const UN_GOAL_URL = "https://sdgs.un.org/goals/goal";
  * SDG1 and SDG5 read black while SDG4, SDG8 and SDG10 read white. That is the
  * choice, not a bug: every badge clears WCAG AA, which a per-hue rule would not.
  *
- * The link role is the native one an <a href> already carries, so no role
- * attribute is set: spelling it out would be redundant ARIA on an element that
- * means it natively.
+ * `interactive` (default true) chooses the badge's element. Interactive renders an
+ * <a href> to the goal's UN page, whose link role and focus ring are native. Passive
+ * (`interactive={false}`) renders a <span role="img"> with the same fill, tooltip and
+ * accessible name but no link: it is for surfaces where the badge sits inside another
+ * anchor — the project cards are a single <Link>, and a nested <a> there is invalid
+ * HTML — so the colour-and-tooltip indicator stands in for the goal link.
  */
-export default function SdgBadge({ sdgCode }) {
+export default function SdgBadge({ sdgCode, interactive = true }) {
     const goals = parseSdgGoals(sdgCode);
     if (!goals.length) return null;
 
     return (
         <span className="inline-flex flex-wrap items-center gap-1">
-            {goals.map(goal => <SdgGoalBadge key={goal.number} goal={goal} />)}
+            {goals.map(goal => <SdgGoalBadge key={goal.number} goal={goal} interactive={interactive} />)}
         </span>
     );
 }
@@ -48,25 +51,35 @@ export default function SdgBadge({ sdgCode }) {
  * One goal's badge. Split out because each badge needs its own ref for the
  * tooltip, and hooks cannot be called from inside the map above.
  */
-function SdgGoalBadge({ goal }) {
+function SdgGoalBadge({ goal, interactive }) {
     const badgeRef = useRef(null);
+    const Tag = interactive ? "a" : "span";
+
+    // The link carries the new-tab attributes and the focus ring. The passive span
+    // carries neither; it also swaps the custom Tooltip for a native `title`, because
+    // its only home is the project card, whose overflow-hidden frame would clip an
+    // absolutely-positioned tooltip to an unreadable sliver. A native title is drawn
+    // by the browser outside that frame. The span still needs an explicit role="img"
+    // so its aria-label is announced (an <a href> announces as a link natively).
+    // ring-offset keeps the focus ring off the fill: the primary ring against an
+    // orange goal colour (SDG9, SDG11) would otherwise barely read.
+    const roleProps = interactive
+        ? { href: `${UN_GOAL_URL}${goal.number}`, target: "_blank", rel: "noopener noreferrer" }
+        : { role: "img", title: goal.name };
+    const focusRing = interactive ? " focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50" : "";
 
     return (
-        <a
+        <Tag
             ref={badgeRef}
             data-testid="sdg-badge"
             data-sdg-code={`SDG${goal.number}`}
-            href={`${UN_GOAL_URL}${goal.number}`}
-            target="_blank"
-            rel="noopener noreferrer"
             aria-label={`SDG ${goal.number}: ${goal.name}`}
-            // ring-offset keeps the focus ring off the fill: the primary ring against
-            // an orange goal colour (SDG9, SDG11) would otherwise barely read.
-            className="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/50 transition-transform hover:scale-110"
+            className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold transition-transform hover:scale-110${focusRing}`}
             style={legibleFill(goal.color)}
+            {...roleProps}
         >
             <span data-testid="sdg-badge-number" aria-hidden="true">{goal.number}</span>
-            <Tooltip parentRef={badgeRef}>{goal.name}</Tooltip>
-        </a>
+            {interactive && <Tooltip parentRef={badgeRef}>{goal.name}</Tooltip>}
+        </Tag>
     );
 }

--- a/projojo_frontend/src/components/SdgBadge.jsx
+++ b/projojo_frontend/src/components/SdgBadge.jsx
@@ -1,0 +1,63 @@
+import { useRef } from "react";
+import Tooltip from "./Tooltip";
+import { parseSdgGoals } from "../utils/sdg";
+import { legibleFill } from "../utils/themeColor";
+
+const UN_GOAL_URL = "https://sdgs.un.org/goals/goal";
+
+/**
+ * SdgBadge Component (TS-task-022)
+ *
+ * Renders a theme's `sdg_code` as one small round badge per UN Sustainable
+ * Development Goal, filled with that goal's official UN colour and linking to
+ * its page on sdgs.un.org.
+ *
+ *   <SdgBadge sdgCode="SDG12" />       one badge
+ *   <SdgBadge sdgCode="SDG2,SDG12" />  one badge per goal
+ *   <SdgBadge sdgCode={null} />        nothing at all
+ *
+ * The number is the only visible content, so the goal's Dutch name is carried
+ * twice over: as the link's accessible name for screen readers, and as the
+ * hover/focus tooltip for sighted users. The number itself is aria-hidden, so a
+ * screen reader announces "SDG 12: Verantwoorde consumptie en productie" rather
+ * than a bare "12".
+ *
+ * The label colour is picked by legibleFill rather than by a fixed rule: the 17
+ * official colours span very light (#FCC30B) to very dark (#19486A), and only a
+ * contrast-based choice keeps every one of them readable.
+ */
+export default function SdgBadge({ sdgCode }) {
+    const goals = parseSdgGoals(sdgCode);
+    if (!goals.length) return null;
+
+    return (
+        <span className="inline-flex flex-wrap items-center gap-1">
+            {goals.map(goal => <SdgGoalBadge key={goal.number} goal={goal} />)}
+        </span>
+    );
+}
+
+/**
+ * One goal's badge. Split out because each badge needs its own ref for the
+ * tooltip, and hooks cannot be called from inside the map above.
+ */
+function SdgGoalBadge({ goal }) {
+    const badgeRef = useRef(null);
+
+    return (
+        <a
+            ref={badgeRef}
+            data-testid="sdg-badge"
+            data-sdg-code={`SDG${goal.number}`}
+            href={`${UN_GOAL_URL}${goal.number}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`SDG ${goal.number}: ${goal.name}`}
+            className="inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-bold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-300 transition-transform hover:scale-110"
+            style={legibleFill(goal.color)}
+        >
+            <span data-testid="sdg-badge-number" aria-hidden="true">{goal.number}</span>
+            <Tooltip parentRef={badgeRef}>{goal.name}</Tooltip>
+        </a>
+    );
+}

--- a/projojo_frontend/src/components/ThemeCreateModal.jsx
+++ b/projojo_frontend/src/components/ThemeCreateModal.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { createTheme } from "../services";
 import Modal from "./Modal";
-import ThemeForm, { EMPTY_FORM, joinSdgCodes } from "./ThemeForm";
+import ThemeForm, { EMPTY_FORM } from "./ThemeForm";
+import { joinSdgCodes } from "../utils/sdg";
 
 /**
  * Teacher-facing "Nieuw thema" create form (TS-task-011).

--- a/projojo_frontend/src/components/ThemeEditModal.jsx
+++ b/projojo_frontend/src/components/ThemeEditModal.jsx
@@ -2,7 +2,8 @@ import { useLayoutEffect, useRef, useState } from "react";
 import { updateTheme } from "../services";
 import Modal from "./Modal";
 import { notification } from "./notifications/NotifySystem";
-import ThemeForm, { DEFAULT_COLOR, EMPTY_FORM, joinSdgCodes, parseSdgCodes } from "./ThemeForm";
+import ThemeForm, { DEFAULT_COLOR, EMPTY_FORM } from "./ThemeForm";
+import { joinSdgCodes, parseSdgCodes } from "../utils/sdg";
 
 /** Map a persisted theme record onto the shared form shape. */
 function themeToForm(theme) {

--- a/projojo_frontend/src/components/ThemeForm.jsx
+++ b/projojo_frontend/src/components/ThemeForm.jsx
@@ -1,15 +1,12 @@
 import { useId, useRef } from "react";
-import { SDG_OPTIONS } from "../utils/sdg";
+// SDG1-SDG17 with their Dutch labels, and the code join/parse helpers, all live
+// in utils/sdg.js so the form and SdgBadge (TS-task-022) read one catalog.
+import { SDG_OPTIONS, joinSdgCodes } from "../utils/sdg";
 
 export const DESCRIPTION_MAX_LENGTH = 500;
 export const DEFAULT_COLOR = "#4caf50";
 
 export const EMPTY_FORM = { name: "", description: "", sdgCodes: [], icon: "", color: DEFAULT_COLOR };
-
-// SDG1-SDG17 with their Dutch labels, and the code join/parse helpers, all live
-// in utils/sdg.js so the form and SdgBadge (TS-task-022) read one catalog.
-// Re-exported here because the create/edit modals import them from this form.
-export { SDG_OPTIONS, joinSdgCodes, parseSdgCodes } from "../utils/sdg";
 
 // Curated Material Symbols icons relevant to themes (sustainability, nature,
 // education, technology, society, economy, infrastructure).
@@ -64,8 +61,9 @@ export default function ThemeForm({ testId, form, onChange, error, isSaving, onS
         if (iconDetailsRef.current) iconDetailsRef.current.open = false;
     };
 
+    // Same canonical order the form saves in, spaced out for reading.
     const sdgSummary = form.sdgCodes.length
-        ? SDG_OPTIONS.filter(option => form.sdgCodes.includes(option.code)).map(option => option.code).join(", ")
+        ? joinSdgCodes(form.sdgCodes).replaceAll(",", ", ")
         : "Selecteer SDG('s)";
 
     return (

--- a/projojo_frontend/src/components/ThemeForm.jsx
+++ b/projojo_frontend/src/components/ThemeForm.jsx
@@ -128,6 +128,14 @@ export default function ThemeForm({ testId, form, onChange, error, isSaving, onS
                                         checked={form.sdgCodes.includes(option.code)}
                                         onChange={() => toggleSdg(option.code)}
                                     />
+                                    {/* Official UN colour preview beside the label, so the code the badge
+                                        will show is recognisable while choosing (TS-task-023 AC-2). */}
+                                    <span
+                                        data-testid={`theme-sdg-swatch-${option.code}`}
+                                        className="w-4 h-4 rounded-sm shrink-0"
+                                        style={{ backgroundColor: option.color }}
+                                        aria-hidden="true"
+                                    />
                                     <span className="text-sm text-[var(--text-primary)]">{option.code} — {option.label}</span>
                                 </label>
                             </li>

--- a/projojo_frontend/src/components/ThemeForm.jsx
+++ b/projojo_frontend/src/components/ThemeForm.jsx
@@ -1,30 +1,15 @@
 import { useId, useRef } from "react";
+import { SDG_OPTIONS } from "../utils/sdg";
 
 export const DESCRIPTION_MAX_LENGTH = 500;
 export const DEFAULT_COLOR = "#4caf50";
 
 export const EMPTY_FORM = { name: "", description: "", sdgCodes: [], icon: "", color: DEFAULT_COLOR };
 
-// SDG1–SDG17 with their Dutch labels (THEME_SDG_IMPLEMENTATION_PLAN.md §3.1).
-export const SDG_OPTIONS = [
-    { code: "SDG1", label: "Geen armoede" },
-    { code: "SDG2", label: "Geen honger" },
-    { code: "SDG3", label: "Goede gezondheid en welzijn" },
-    { code: "SDG4", label: "Kwaliteitsonderwijs" },
-    { code: "SDG5", label: "Gendergelijkheid" },
-    { code: "SDG6", label: "Schoon water en sanitair" },
-    { code: "SDG7", label: "Betaalbare en duurzame energie" },
-    { code: "SDG8", label: "Waardig werk en economische groei" },
-    { code: "SDG9", label: "Industrie, innovatie en infrastructuur" },
-    { code: "SDG10", label: "Ongelijkheid verminderen" },
-    { code: "SDG11", label: "Duurzame steden en gemeenschappen" },
-    { code: "SDG12", label: "Verantwoorde consumptie en productie" },
-    { code: "SDG13", label: "Klimaatactie" },
-    { code: "SDG14", label: "Leven in het water" },
-    { code: "SDG15", label: "Leven op het land" },
-    { code: "SDG16", label: "Vrede, justitie en sterke instellingen" },
-    { code: "SDG17", label: "Partnerschap om doelstellingen te bereiken" },
-];
+// SDG1-SDG17 with their Dutch labels, and the code join/parse helpers, all live
+// in utils/sdg.js so the form and SdgBadge (TS-task-022) read one catalog.
+// Re-exported here because the create/edit modals import them from this form.
+export { SDG_OPTIONS, joinSdgCodes, parseSdgCodes } from "../utils/sdg";
 
 // Curated Material Symbols icons relevant to themes (sustainability, nature,
 // education, technology, society, economy, infrastructure).
@@ -45,16 +30,6 @@ export const ICON_OPTIONS = [
     "business_center", "factory", "storefront", "savings", "payments", "trending_up",
     "insights", "analytics", "workspace_premium", "verified", "emoji_events", "category",
 ];
-
-/** Join selected SDG codes into the canonical SDG1..SDG17 order, regardless of click order. */
-export function joinSdgCodes(sdgCodes) {
-    return SDG_OPTIONS.filter(option => sdgCodes.includes(option.code)).map(option => option.code).join(",");
-}
-
-/** Parse a stored "SDG2,SDG12" code string back into an array of codes. */
-export function parseSdgCodes(sdgCode) {
-    return sdgCode ? sdgCode.split(",").map(code => code.trim()).filter(Boolean) : [];
-}
 
 /**
  * Shared theme form used by both the create (TS-task-011) and edit (TS-task-012)

--- a/projojo_frontend/src/components/ThemeManagement.jsx
+++ b/projojo_frontend/src/components/ThemeManagement.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { getThemes } from "../services";
 import Alert from "./Alert";
 import Loading from "./Loading";
+import SdgBadge from "./SdgBadge";
 import ThemeCreateModal from "./ThemeCreateModal";
 import ThemeDeleteModal from "./ThemeDeleteModal";
 import ThemeEditModal from "./ThemeEditModal";
@@ -127,7 +128,11 @@ export default function ThemeManagement() {
                                         {theme.name}
                                     </th>
                                     <td data-testid="theme-sdg" className="px-4 md:px-6 py-4 text-[var(--text-secondary)]">
-                                        {theme.sdg_code || "—"}
+                                        {/* sdg_code goes to SdgBadge as-is, null included: the badge
+                                            renders nothing for a theme without an SDG, and the dash
+                                            keeps the column readable in that case (TS-task-012). */}
+                                        <SdgBadge sdgCode={theme.sdg_code} />
+                                        {!theme.sdg_code && "—"}
                                     </td>
                                     <td
                                         data-testid="theme-description"

--- a/projojo_frontend/src/components/ThemePicker.jsx
+++ b/projojo_frontend/src/components/ThemePicker.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getThemes } from '../services';
 import { legibleFill, COLORLESS_THEME_FILL } from '../utils/themeColor';
+import SdgBadge from './SdgBadge';
 
 /**
  * ThemePicker - reusable visual theme selector (controlled).
@@ -97,24 +98,18 @@ export default function ThemePicker({ selected = [], onChange, readOnly = false 
                 const color = theme.color || COLORLESS_THEME_FILL;
                 const fillStyle = legibleFill(color);
 
-                if (readOnly) {
-                    return (
-                        <span
-                            key={theme.id}
-                            data-testid="theme-pill"
-                            data-theme-id={theme.id}
-                            data-readonly="true"
-                            className="inline-flex items-center gap-2 px-4 py-2 text-xs font-bold rounded-full border border-transparent cursor-default"
-                            style={fillStyle}
-                        >
-                            {theme.name}
-                        </span>
-                    );
-                }
-
-                return (
+                const pill = readOnly ? (
+                    <span
+                        data-testid="theme-pill"
+                        data-theme-id={theme.id}
+                        data-readonly="true"
+                        className="inline-flex items-center gap-2 px-4 py-2 text-xs font-bold rounded-full border border-transparent cursor-default"
+                        style={fillStyle}
+                    >
+                        {theme.name}
+                    </span>
+                ) : (
                     <button
-                        key={theme.id}
                         type="button"
                         data-testid="theme-pill"
                         data-theme-id={theme.id}
@@ -136,6 +131,21 @@ export default function ThemePicker({ selected = [], onChange, readOnly = false 
                         )}
                         {theme.name}
                     </button>
+                );
+
+                // Pill and its SDG badge as siblings. The badge is the SdgBadge
+                // default (a link to the goal's UN page), safe here because it sits
+                // ADJACENT to the pill, never nested inside the toggle (TS-task-023 AC-3).
+                return (
+                    <span
+                        key={theme.id}
+                        data-testid="theme-pill-group"
+                        data-theme-id={theme.id}
+                        className="inline-flex items-center gap-1.5"
+                    >
+                        {pill}
+                        <SdgBadge sdgCode={theme.sdg_code} />
+                    </span>
                 );
             })}
         </div>

--- a/projojo_frontend/src/utils/sdg.js
+++ b/projojo_frontend/src/utils/sdg.js
@@ -32,8 +32,8 @@ const SDG_GOALS = Object.freeze([
 
 const GOAL_BY_CODE = new Map(SDG_GOALS.map(goal => [`SDG${goal.number}`, goal]));
 
-/** SDG1–SDG17 with their Dutch labels, for the theme form's multi-select. */
-export const SDG_OPTIONS = SDG_GOALS.map(goal => ({ code: `SDG${goal.number}`, label: goal.name }));
+/** SDG1–SDG17 with their Dutch labels and official UN colours, for the theme form's multi-select. */
+export const SDG_OPTIONS = SDG_GOALS.map(goal => ({ code: `SDG${goal.number}`, label: goal.name, color: goal.color }));
 
 /** Join selected SDG codes into the canonical SDG1..SDG17 order, regardless of click order. */
 export function joinSdgCodes(sdgCodes) {

--- a/projojo_frontend/src/utils/sdg.js
+++ b/projojo_frontend/src/utils/sdg.js
@@ -10,7 +10,7 @@
  * number, single ("SDG12") or comma-separated ("SDG2,SDG12"), which is exactly
  * what the backend validates.
  */
-export const SDG_GOALS = Object.freeze([
+const SDG_GOALS = Object.freeze([
     { number: 1, name: "Geen armoede", color: "#E5243B" },
     { number: 2, name: "Geen honger", color: "#DDA63A" },
     { number: 3, name: "Goede gezondheid en welzijn", color: "#4C9F38" },
@@ -46,13 +46,17 @@ export function parseSdgCodes(sdgCode) {
 }
 
 /**
- * The goals a stored sdg_code names, in stored order.
+ * The distinct goals a stored sdg_code names, in stored order.
  *
- * A null/empty code yields an empty list, and so does an unrecognised one: the
- * field is free text as far as the frontend is concerned, and a theme carrying
- * something the UN catalog does not define should render no badge rather than
- * an unlabelled, uncoloured one.
+ * The backend's pattern is SDG<n>(,SDG<n>)*, which accepts the same goal twice,
+ * so "SDG12,SDG12" is real data — and one goal is still one badge however often
+ * it is named. Deduplicating here is also what keeps the goal number usable as a
+ * React key.
+ *
+ * A null or empty code yields an empty list. So does an unrecognised one, which
+ * the backend's pattern already rules out; dropping it keeps this function total
+ * rather than handing a caller a hole where a goal should be.
  */
 export function parseSdgGoals(sdgCode) {
-    return parseSdgCodes(sdgCode).map(code => GOAL_BY_CODE.get(code)).filter(Boolean);
+    return [...new Set(parseSdgCodes(sdgCode))].map(code => GOAL_BY_CODE.get(code)).filter(Boolean);
 }

--- a/projojo_frontend/src/utils/sdg.js
+++ b/projojo_frontend/src/utils/sdg.js
@@ -1,0 +1,58 @@
+/**
+ * The 17 UN Sustainable Development Goals, in goal order.
+ *
+ * One table serves every SDG surface: the Dutch labels in the theme form's
+ * multi-select (TS-task-011/012) and the official UN colours on SdgBadge
+ * (TS-task-022). Keeping the names in a single place is what stops the picker
+ * and the badge from ever disagreeing about what SDG 12 is called.
+ *
+ * A goal's `number` is its identity; the stored `sdg_code` form is "SDG" + that
+ * number, single ("SDG12") or comma-separated ("SDG2,SDG12"), which is exactly
+ * what the backend validates.
+ */
+export const SDG_GOALS = Object.freeze([
+    { number: 1, name: "Geen armoede", color: "#E5243B" },
+    { number: 2, name: "Geen honger", color: "#DDA63A" },
+    { number: 3, name: "Goede gezondheid en welzijn", color: "#4C9F38" },
+    { number: 4, name: "Kwaliteitsonderwijs", color: "#C5192D" },
+    { number: 5, name: "Gendergelijkheid", color: "#FF3A21" },
+    { number: 6, name: "Schoon water en sanitair", color: "#26BDE2" },
+    { number: 7, name: "Betaalbare en duurzame energie", color: "#FCC30B" },
+    { number: 8, name: "Waardig werk en economische groei", color: "#A21942" },
+    { number: 9, name: "Industrie, innovatie en infrastructuur", color: "#FD6925" },
+    { number: 10, name: "Ongelijkheid verminderen", color: "#DD1367" },
+    { number: 11, name: "Duurzame steden en gemeenschappen", color: "#FD9D24" },
+    { number: 12, name: "Verantwoorde consumptie en productie", color: "#BF8B2E" },
+    { number: 13, name: "Klimaatactie", color: "#3F7E44" },
+    { number: 14, name: "Leven in het water", color: "#0A97D9" },
+    { number: 15, name: "Leven op het land", color: "#56C02B" },
+    { number: 16, name: "Vrede, justitie en sterke instellingen", color: "#00689D" },
+    { number: 17, name: "Partnerschap om doelstellingen te bereiken", color: "#19486A" },
+].map(Object.freeze));
+
+const GOAL_BY_CODE = new Map(SDG_GOALS.map(goal => [`SDG${goal.number}`, goal]));
+
+/** SDG1–SDG17 with their Dutch labels, for the theme form's multi-select. */
+export const SDG_OPTIONS = SDG_GOALS.map(goal => ({ code: `SDG${goal.number}`, label: goal.name }));
+
+/** Join selected SDG codes into the canonical SDG1..SDG17 order, regardless of click order. */
+export function joinSdgCodes(sdgCodes) {
+    return SDG_OPTIONS.filter(option => sdgCodes.includes(option.code)).map(option => option.code).join(",");
+}
+
+/** Parse a stored "SDG2,SDG12" code string back into an array of codes. */
+export function parseSdgCodes(sdgCode) {
+    return sdgCode ? sdgCode.split(",").map(code => code.trim()).filter(Boolean) : [];
+}
+
+/**
+ * The goals a stored sdg_code names, in stored order.
+ *
+ * A null/empty code yields an empty list, and so does an unrecognised one: the
+ * field is free text as far as the frontend is concerned, and a theme carrying
+ * something the UN catalog does not define should render no badge rather than
+ * an unlabelled, uncoloured one.
+ */
+export function parseSdgGoals(sdgCode) {
+    return parseSdgCodes(sdgCode).map(code => GOAL_BY_CODE.get(code)).filter(Boolean);
+}

--- a/tests/e2e/features/ts-task-022-sdg-badge-component.feature
+++ b/tests/e2e/features/ts-task-022-sdg-badge-component.feature
@@ -1,0 +1,85 @@
+Feature: TS-task-022 SDG badge component with official UN colours
+
+  As any user of Projojo
+  I want themes to show their SDG as a badge in the official UN colour
+  So that I understand which UN Sustainable Development Goal a theme supports
+
+  # The SdgBadge component is exercised through the teacher theme catalog, the one
+  # surface that renders a theme's sdg_code today. Every scenario resets the live
+  # catalog to the TS-022 fixtures first, so the shared, mutable catalog cannot make
+  # these assertions order-dependent (same contract as TS-task-010).
+  #
+  # Wiring the badge into the remaining theme surfaces is TS-task-023 and is out of
+  # scope here; this suite only proves the component's own behaviour.
+
+  Background:
+    Given I am authenticated in the browser as the TS-task-022 teacher
+    And the theme catalog contains only the TS-022 SDG fixtures
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-1 a single SDG code renders one badge in its official UN colour
+    When I open the TeacherPage
+    Then the theme "SDG Enkel" should show exactly 1 SDG badge
+    And the SDG badge for "SDG12" on theme "SDG Enkel" should show the number "12"
+    And the SDG badge for "SDG12" on theme "SDG Enkel" should be filled with "#BF8B2E"
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-2 all seventeen SDGs render in their official UN colours
+    When I open the TeacherPage
+    Then the theme "SDG Alle" should show exactly 17 SDG badges
+    And every SDG badge on theme "SDG Alle" should be filled with its official UN colour
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-3 hovering a badge reveals the Dutch SDG name
+    When I open the TeacherPage
+    Then the tooltip of the SDG badge for "SDG12" on theme "SDG Enkel" should be hidden
+    When I hover the SDG badge for "SDG12" on theme "SDG Enkel"
+    Then the tooltip "Verantwoorde consumptie en productie" should become visible
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-4 clicking a badge opens the UN goal page in a new tab
+    When I open the TeacherPage
+    And I click the SDG badge for "SDG12" on theme "SDG Enkel"
+    Then a new browser tab should have opened at "https://sdgs.un.org/goals/goal12"
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-5 a compound SDG code renders one badge per goal
+    When I open the TeacherPage
+    Then the theme "SDG Samengesteld" should show exactly 2 SDG badges
+    And the SDG badges on theme "SDG Samengesteld" should be "SDG2" and "SDG12" in that order
+    And each SDG badge on theme "SDG Samengesteld" should carry its own colour, tooltip and goal link
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-6 a theme without an SDG code renders no badge and no error
+    Given I am recording browser errors
+    When I open the TeacherPage
+    Then the theme "SDG Geen" should show no SDG badge
+    And the theme "SDG Geen" should still render its name and description
+    And no browser error should have been recorded
+
+  @ui @theme @sdg @TS-task-022
+  Scenario Outline: AC-7 badge text is legible on both dark and light SDG fills
+    When I open the TeacherPage
+    Then the SDG badge for "<code>" on theme "<theme>" should have text colour "<textColour>"
+
+    Examples:
+      | theme      | code  | textColour |
+      | SDG Donker | SDG17 | #FFFFFF    |
+      | SDG Licht  | SDG7  | #000000    |
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-7 every SDG badge clears the WCAG AA contrast threshold
+    When I open the TeacherPage
+    Then every SDG badge on theme "SDG Alle" should meet WCAG AA contrast
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-8 a badge is announced with its full SDG name and exposed as a link
+    When I open the TeacherPage
+    Then the SDG badge for "SDG12" on theme "SDG Enkel" should be a link announced as "SDG 12: Verantwoorde consumptie en productie"
+    And the number inside that badge should be hidden from assistive technology
+
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-8 a badge is reachable by keyboard and shows a visible focus indicator
+    When I open the TeacherPage
+    And I tab forwards until the SDG badge for "SDG12" on theme "SDG Enkel" has focus
+    Then that SDG badge should show a focus indicator it does not show when unfocused

--- a/tests/e2e/features/ts-task-022-sdg-badge-component.feature
+++ b/tests/e2e/features/ts-task-022-sdg-badge-component.feature
@@ -27,7 +27,7 @@ Feature: TS-task-022 SDG badge component with official UN colours
   Scenario: AC-2 all seventeen SDGs render in their official UN colours
     When I open the TeacherPage
     Then the theme "SDG Alle" should show exactly 17 SDG badges
-    And every SDG badge on theme "SDG Alle" should be filled with its official UN colour
+    And every SDG badge on theme "SDG Alle" should show its goal number in its official UN colour
 
   @ui @theme @sdg @TS-task-022
   Scenario: AC-3 hovering a badge reveals the Dutch SDG name
@@ -49,11 +49,24 @@ Feature: TS-task-022 SDG badge component with official UN colours
     And the SDG badges on theme "SDG Samengesteld" should be "SDG2" and "SDG12" in that order
     And each SDG badge on theme "SDG Samengesteld" should carry its own colour, tooltip and goal link
 
+  # The stored code is free to repeat a goal - the backend pattern SDG<n>(,SDG<n>)*
+  # accepts 'SDG12,SDG12' - and one goal is one badge however often it is named.
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-5 a repeated SDG code still renders a single badge
+    Given I am recording browser errors
+    When I open the TeacherPage
+    Then the theme "SDG Dubbel" should show exactly 1 SDG badge
+    And the SDG badge for "SDG12" on theme "SDG Dubbel" should be filled with "#BF8B2E"
+    And no browser error should have been recorded
+
+  # The "SDG Enkel" line is the positive control: without it every step here also
+  # passes for a component that renders nothing at all, whatever it is given.
   @ui @theme @sdg @TS-task-022
   Scenario: AC-6 a theme without an SDG code renders no badge and no error
     Given I am recording browser errors
     When I open the TeacherPage
     Then the theme "SDG Geen" should show no SDG badge
+    And the theme "SDG Enkel" should show exactly 1 SDG badge
     And the theme "SDG Geen" should still render its name and description
     And no browser error should have been recorded
 

--- a/tests/e2e/features/ts-task-023-sdg-badge-integration.feature
+++ b/tests/e2e/features/ts-task-023-sdg-badge-integration.feature
@@ -1,0 +1,151 @@
+Feature: TS-task-023 SDG badge integration across theme views
+
+  As any user of Projojo
+  I want SDG badges shown wherever themes are displayed
+  So that the SDG dimension is consistently visible and never hidden in the data
+
+  # TS-task-022 built the SdgBadge and wired it into the teacher theme catalog. This
+  # task carries the same badge onto every other surface a theme appears on: the SDG
+  # picker inside the create/edit modal (AC-2), the ThemePicker pills (AC-3), the
+  # project details theme section (AC-4) and the project cards (AC-5) - while a theme
+  # with no SDG code stays badge-free everywhere (AC-6).
+  #
+  # Runs against the real stack. Expected SDG colours, names, codes and goal URLs
+  # come from support/sdg-catalog.cjs, which hardcodes them from the issue rather
+  # than importing the component's own table, so these assertions answer to the
+  # specification, not to the code under test.
+  #
+  # Where the badge is a link vs a passive indicator is deliberate, not incidental:
+  #   - Teacher catalog, ThemePicker pills and the details pills carry the clickable
+  #     link to the goal's UN page (the SdgBadge default) - they are safe places for
+  #     it: the picker/details badges sit ADJACENT to their pill, so the link is a
+  #     sibling, never nested inside another control.
+  #   - The project cards render a NON-interactive badge (colour + hover/focus
+  #     tooltip only): the whole card is a single <Link>, and a nested <a> there is
+  #     invalid HTML. The issue's AC-5 explicitly allows a tooltip when space is
+  #     tight, which is exactly this case.
+
+  # --- AC-1: the teacher theme management list -----------------------------------
+
+  # TS-task-022 owns the badge's deep behaviour on this surface; here we assert only
+  # the integration claim of AC-1 - the badge renders in the theme's own row, beside
+  # its name - reusing the TS-022 row steps so this cannot drift from that suite.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-1 the theme management list shows a theme's SDG badge in its row
+    Given I am authenticated in the browser as the TS-task-022 teacher
+    And the theme catalog contains only the TS-022 SDG fixtures
+    When I open the TeacherPage
+    Then the theme "SDG Enkel" should show exactly 1 SDG badge
+    And the SDG badge for "SDG12" on theme "SDG Enkel" should show the number "12"
+    And the theme row "SDG Enkel" shows its SDG badge for "SDG12" beside the theme name
+
+  # --- AC-2: the SDG picker inside the create/edit modal --------------------------
+
+  # The create and edit modals render the same shared ThemeForm, so proving the
+  # colour preview in the create modal proves it for both.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-2 each SDG picker option shows its official UN colour beside the label
+    Given I am authenticated in the browser as the TS-task-022 teacher
+    And the theme catalog contains only the TS-022 SDG fixtures
+    When I open the TeacherPage
+    And I open the theme create modal
+    And I open the SDG code dropdown
+    Then the SDG option "SDG12" shows a UN colour preview filled with "#BF8B2E"
+    And the SDG option "SDG12" still reads "SDG12 — Verantwoorde consumptie en productie"
+    And every SDG option shows a UN colour preview in its own official UN colour
+
+  # --- AC-3: the ThemePicker pills -----------------------------------------------
+
+  # Driven through the ThemePicker dev harness (/dev/theme-picker) with a stubbed
+  # catalog, the same way TS-task-014 isolates the component. A themed and an
+  # unthemed theme together prove both the presence and the absence of the badge.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-3 a ThemePicker pill carries the SDG badge for a theme that has an SDG code
+    Given the theme picker lists a theme "Duurzaamheid" with SDG code "SDG12" and a theme "Zonder SDG" with no SDG code
+    When I open the SDG-themed theme picker demo
+    Then the theme picker pill "Duurzaamheid" shows an adjacent SDG badge for "SDG12"
+    And the picker SDG badge for "SDG12" links to the UN goal page for "SDG12"
+    And the theme picker pill "Zonder SDG" shows no SDG badge
+
+  # --- AC-4: the project details theme section -----------------------------------
+
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-4 the project details theme pills carry their SDG badge as a UN goal link
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Enkel"
+    And I am authenticated in the browser as a student
+    When I open the project details page
+    Then the project theme pill "SDG Enkel" shows an adjacent SDG badge for "SDG12"
+    And the details SDG badge for "SDG12" links to the UN goal page for "SDG12"
+
+  # AC-6 on the details surface. "SDG Enkel" is the positive control, so "no badge"
+  # on "SDG Geen" cannot pass for a section that simply renders no badges at all.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-6 a details theme pill without an SDG code shows no badge and renders normally
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Enkel, SDG Geen"
+    And I am authenticated in the browser as a student
+    When I open the project details page
+    Then the project theme pill "SDG Enkel" shows an adjacent SDG badge for "SDG12"
+    And the project theme pill "SDG Geen" shows no SDG badge
+    And the "SDG Geen" theme pill is labelled "SDG Geen"
+
+  # --- AC-5: the project cards ----------------------------------------------------
+
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-5 the organisation project card shows the primary theme's SDG badge
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Enkel"
+    And I am authenticated in the browser as a student
+    When I open the organisation page of the project's business
+    Then the project card shows exactly one theme badge
+    And the project card theme badge shows an SDG badge for "SDG12"
+    And the project card SDG badge is a passive indicator, not a link
+
+  # A theme can carry several SDG codes. The card draws up to two goal badges; two
+  # codes fit exactly, so both show and no "+N" appears.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-5 a project card whose primary theme has two SDG codes shows both badges
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Samengesteld"
+    And I am authenticated in the browser as a student
+    When I open the organisation page of the project's business
+    Then the project card shows exactly one theme badge
+    And the project card theme badge shows an SDG badge for "SDG2"
+    And the project card theme badge shows an SDG badge for "SDG12"
+    And the project card shows exactly 2 SDG badges
+    And the project card SDG badges show no overflow count
+
+  # Beyond two goals the card caps at the first two badges and collapses the rest into
+  # a "+N" count, the same way several themes collapse into the theme badge's own "+N" -
+  # so the badges never run across the status badge in the opposite corner.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-5 a project card whose primary theme has many SDG codes caps at two badges with a +N count
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Alle"
+    And I am authenticated in the browser as a student
+    When I open the organisation page of the project's business
+    Then the project card shows exactly one theme badge
+    And the project card theme badge shows an SDG badge for "SDG1"
+    And the project card theme badge shows an SDG badge for "SDG2"
+    And the project card shows exactly 2 SDG badges
+    And the project card SDG badge shows an overflow count of "+15"
+
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-5 the public project card shows the primary theme's SDG badge
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Enkel"
+    And the project is publicly visible
+    When I open the public discovery page
+    Then the public project card theme badge shows an SDG badge for "SDG12"
+
+  # AC-6 on the card surface: a project whose primary theme has no SDG code keeps its
+  # single theme badge but shows no SDG badge.
+  @ui @theme @sdg @TS-task-023
+  Scenario: AC-6 a project card whose primary theme has no SDG code shows no SDG badge
+    Given the theme catalog contains only the TS-022 SDG fixtures
+    And the project's linked themes are "SDG Geen"
+    And I am authenticated in the browser as a student
+    When I open the organisation page of the project's business
+    Then the project card shows exactly one theme badge
+    And the project card theme badge shows no SDG badge

--- a/tests/e2e/features/ts-task-023-sdg-badge-integration.feature
+++ b/tests/e2e/features/ts-task-023-sdg-badge-integration.feature
@@ -117,8 +117,11 @@ Feature: TS-task-023 SDG badge integration across theme views
     And the project card SDG badges show no overflow count
 
   # Beyond two goals the card caps at the first two badges and collapses the rest into
-  # a "+N" count, the same way several themes collapse into the theme badge's own "+N" -
-  # so the badges never run across the status badge in the opposite corner.
+  # a "+N" count, the same way several themes collapse into the theme badge's own "+N",
+  # so the SDG badge row stays bounded rather than growing one badge per goal. (The cap
+  # bounds only the SDG contribution to the row width; it is not on its own a guarantee
+  # against meeting the opposite-corner status badge, which also depends on the theme
+  # name length - the name is truncated for that, and no scenario asserts the overlap.)
   @ui @theme @sdg @TS-task-023
   Scenario: AC-5 a project card whose primary theme has many SDG codes caps at two badges with a +N count
     Given the theme catalog contains only the TS-022 SDG fixtures

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -114,7 +114,15 @@ Then('every theme row should show its color swatch, icon, name, SDG code and des
     assert.equal(backgroundColor, hexToRgb(theme.color), `Expected swatch for '${theme.name}' to use color ${theme.color}`);
 
     assert.equal((await row.getByTestId('theme-icon').innerText()).trim(), theme.icon, `Expected icon '${theme.icon}' for '${theme.name}'`);
-    assert.equal((await row.getByTestId('theme-sdg').innerText()).trim(), theme.sdg_code, `Expected SDG '${theme.sdg_code}' for '${theme.name}'`);
+
+    // Since TS-task-022 the SDG cell renders SdgBadge rather than the raw code, so
+    // the code is read back off the badges. Still the same assertion - the row shows
+    // this theme's SDG code - just against the element that now carries it.
+    const renderedSdgCodes = await row
+      .getByTestId('theme-sdg')
+      .getByTestId('sdg-badge')
+      .evaluateAll((badges) => badges.map((badge) => badge.dataset.sdgCode));
+    assert.deepEqual(renderedSdgCodes, theme.sdg_code.split(','), `Expected SDG '${theme.sdg_code}' for '${theme.name}'`);
 
     const description = (await row.getByTestId('theme-description').innerText()).trim();
     assert.ok(description.length > 0, `Expected a visible description for '${theme.name}'`);

--- a/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
+++ b/tests/e2e/steps/ts-task-010-theme-management-list.steps.cjs
@@ -116,13 +116,15 @@ Then('every theme row should show its color swatch, icon, name, SDG code and des
     assert.equal((await row.getByTestId('theme-icon').innerText()).trim(), theme.icon, `Expected icon '${theme.icon}' for '${theme.name}'`);
 
     // Since TS-task-022 the SDG cell renders SdgBadge rather than the raw code, so
-    // the code is read back off the badges. Still the same assertion - the row shows
-    // this theme's SDG code - just against the element that now carries it.
-    const renderedSdgCodes = await row
-      .getByTestId('theme-sdg')
-      .getByTestId('sdg-badge')
-      .evaluateAll((badges) => badges.map((badge) => badge.dataset.sdgCode));
-    assert.deepEqual(renderedSdgCodes, theme.sdg_code.split(','), `Expected SDG '${theme.sdg_code}' for '${theme.name}'`);
+    // a code now shows as its goal number inside a badge. Still the same assertion -
+    // the row shows this theme's SDG - read off what the teacher actually sees.
+    const renderedSdgNumbers = (await row.getByTestId('theme-sdg').getByTestId('sdg-badge-number').allInnerTexts())
+      .map((number) => number.trim());
+    assert.deepEqual(
+      renderedSdgNumbers,
+      theme.sdg_code.split(',').map((code) => code.replace('SDG', '')),
+      `Expected SDG '${theme.sdg_code}' for '${theme.name}'`,
+    );
 
     const description = (await row.getByTestId('theme-description').innerText()).trim();
     assert.ok(description.length > 0, `Expected a visible description for '${theme.name}'`);

--- a/tests/e2e/steps/ts-task-019-theme-display-on-project-details.steps.cjs
+++ b/tests/e2e/steps/ts-task-019-theme-display-on-project-details.steps.cjs
@@ -295,11 +295,17 @@ Then('the theme section offers no theme editing control', async function () {
   await section(this).getByTestId('project-themes-loading').waitFor({ state: 'detached', timeout: 15_000 });
   // No editing affordance of any shape - a button, link, select, input, editable
   // region or role="button" would all count as an edit control a user who may not
-  // edit this project's themes must never be offered.
+  // edit this project's themes must never be offered. The SDG badges (TS-task-023)
+  // are the one exemption: each themed pill carries an adjacent link to the goal's
+  // UN page, which is a read-only informational link, not an edit affordance. Each
+  // badge is a single <a> with no interactive descendants, so subtracting the badge
+  // count leaves exactly the count of genuine edit controls, which must be zero.
+  const interactiveCount = await section(this).locator(INTERACTIVE_SELECTOR).count();
+  const sdgBadgeCount = await section(this).getByTestId('sdg-badge').count();
   assert.equal(
-    await section(this).locator(INTERACTIVE_SELECTOR).count(),
+    interactiveCount - sdgBadgeCount,
     0,
-    'Expected the theme section to offer no editing control of any kind',
+    'Expected the theme section to offer no editing control of any kind beyond the read-only SDG goal links',
   );
 });
 

--- a/tests/e2e/steps/ts-task-019-theme-display-on-project-details.steps.cjs
+++ b/tests/e2e/steps/ts-task-019-theme-display-on-project-details.steps.cjs
@@ -295,18 +295,37 @@ Then('the theme section offers no theme editing control', async function () {
   await section(this).getByTestId('project-themes-loading').waitFor({ state: 'detached', timeout: 15_000 });
   // No editing affordance of any shape - a button, link, select, input, editable
   // region or role="button" would all count as an edit control a user who may not
-  // edit this project's themes must never be offered. The SDG badges (TS-task-023)
-  // are the one exemption: each themed pill carries an adjacent link to the goal's
-  // UN page, which is a read-only informational link, not an edit affordance. Each
-  // badge is a single <a> with no interactive descendants, so subtracting the badge
-  // count leaves exactly the count of genuine edit controls, which must be zero.
-  const interactiveCount = await section(this).locator(INTERACTIVE_SELECTOR).count();
-  const sdgBadgeCount = await section(this).getByTestId('sdg-badge').count();
-  assert.equal(
-    interactiveCount - sdgBadgeCount,
-    0,
-    'Expected the theme section to offer no editing control of any kind beyond the read-only SDG goal links',
+  // edit this project's themes must never be offered. The SDG goal links
+  // (TS-task-023) are the one exemption: each themed pill carries an adjacent,
+  // read-only link to the goal's UN page, not an edit affordance. They are excluded
+  // by test id rather than subtracted as a count, so the check stays structural: a
+  // leaked edit control can no longer be cancelled out by a missing badge, and the
+  // failure names the offending element instead of reporting a bare (or negative)
+  // number.
+  const editControlSelector = INTERACTIVE_SELECTOR
+    .split(', ')
+    .map((part) => `${part}:not([data-testid="sdg-badge"])`)
+    .join(', ');
+  const offenders = await section(this)
+    .locator(editControlSelector)
+    .evaluateAll((elements) => elements.map((element) => element.outerHTML));
+  assert.deepEqual(
+    offenders,
+    [],
+    `Expected the theme section to offer no editing control beyond the read-only SDG goal links, found: ${offenders.join(' | ')}`,
   );
+
+  // Earn the exemption inside this file: every element it waved through must really
+  // be an SDG goal link, not merely anything wearing the badge's test id.
+  for (const badge of await section(this).getByTestId('sdg-badge').all()) {
+    const [tag, href] = await badge.evaluate((element) => [element.tagName, element.getAttribute('href')]);
+    assert.equal(tag, 'A', 'Expected an exempted SDG badge to be a link');
+    assert.match(
+      href ?? '',
+      /^https:\/\/sdgs\.un\.org\/goals\/goal\d+$/,
+      `Expected an exempted SDG badge to link to a UN goal page, got '${href}'`,
+    );
+  }
 });
 
 // --- Then: graceful degradation --------------------------------------------------

--- a/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
+++ b/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
@@ -63,6 +63,30 @@ async function badgeFor(world, themeName, code) {
  */
 const tooltipOf = (badge) => badge.locator('[role="tooltip"]');
 
+/**
+ * The tooltip's opacity once its fade has settled.
+ *
+ * Playwright's visibility check looks at visibility/display and box size, not at
+ * opacity, so a tooltip that flips to `visibility: visible` but never fades in
+ * still counts as visible to `waitFor`. The tooltip transitions opacity over
+ * 300ms, so reading it once catches it mid-fade; this settles on the final value
+ * instead, which is what "becomes visible" has to mean to be worth asserting.
+ */
+function settledOpacity(tooltip, timeoutMs = 2000) {
+  return tooltip.evaluate(
+    (element, budget) => new Promise((resolve) => {
+      const deadline = Date.now() + budget;
+      const read = () => {
+        const opacity = Number(getComputedStyle(element).opacity);
+        if (opacity >= 1 || Date.now() > deadline) resolve(opacity);
+        else requestAnimationFrame(read);
+      };
+      read();
+    }),
+    timeoutMs,
+  );
+}
+
 /** The badge's rendered fill and its number's rendered text colour. */
 async function renderedColours(badge) {
   const backgroundColor = await badge.evaluate((el) => getComputedStyle(el).backgroundColor);
@@ -96,6 +120,10 @@ Given('the theme catalog contains only the TS-022 SDG fixtures', async function 
   await resetThemeCatalog(TS022_THEME_PAYLOADS);
 });
 
+// Deliberately a step rather than a hook: the Background's authentication already
+// renders the landing page, which logs a pre-existing React warning of its own.
+// Recording from here on means these scenarios answer for the theme page they are
+// about, instead of failing on noise made before it was ever opened.
 Given('I am recording browser errors', async function () {
   this.browserErrors = [];
   const current = page(this);
@@ -153,7 +181,7 @@ Then('the SDG badge for {string} on theme {string} should be filled with {string
   assert.equal(backgroundColor, hexToRgb(hex), `Expected the '${code}' badge to be filled with ${hex}`);
 });
 
-Then('every SDG badge on theme {string} should be filled with its official UN colour', async function (themeName) {
+Then('every SDG badge on theme {string} should show its goal number in its official UN colour', async function (themeName) {
   const badges = await badgesOn(this, themeName);
   await badges.first().waitFor({ state: 'visible' });
   const expectedCodes = expectedCodesFor(themeName);
@@ -168,6 +196,13 @@ Then('every SDG badge on theme {string} should be filled with its official UN co
       backgroundColor,
       hexToRgb(expectedColor(code)),
       `Expected ${code} to be filled with its official UN colour ${expectedColor(code)}`,
+    );
+    // The number is checked here too, not only for the one badge AC-1 names, so a
+    // goal that renders the wrong digit cannot hide behind the right fill colour.
+    assert.equal(
+      (await badge.getByTestId('sdg-badge-number').innerText()).trim(),
+      String(sdgNumber(code)),
+      `Expected the ${code} badge to show '${sdgNumber(code)}'`,
     );
   }
 });
@@ -191,6 +226,8 @@ Then('the tooltip {string} should become visible', async function (expectedText)
   assert.equal(expectedText, expectedName(this.hoveredCode), `Scenario tooltip must be the Dutch name of ${this.hoveredCode}`);
   const tooltip = tooltipOf(this.hoveredBadge);
   await tooltip.waitFor({ state: 'visible' });
+  const opacity = await settledOpacity(tooltip);
+  assert.ok(opacity >= 1, `Expected the tooltip to fade fully in, opacity settled at ${opacity}`);
   assert.equal((await tooltip.innerText()).trim(), expectedText, 'Expected the tooltip to show the Dutch SDG name');
 });
 

--- a/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
+++ b/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
@@ -1,0 +1,323 @@
+// TS-task-022 - SDG badge component with official UN colours.
+//
+// The badge is driven through the teacher theme catalog, the only surface that
+// renders a theme's sdg_code today. Expected colours, Dutch names, accessible
+// names and goal URLs all come from support/sdg-catalog.cjs, which hardcodes them
+// from the issue rather than importing the component's own table, so these steps
+// assert against the specification instead of against the code under test.
+
+const assert = require('node:assert/strict');
+
+const { Given, When, Then } = require('@qavajs/core');
+
+const { E2E_TEACHER_ID } = require('../support/test-data.cjs');
+const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
+const { resetThemeCatalog } = require('../support/theme-catalog.cjs');
+const { hexToRgb, parseCssColor, contrastRatio, MINIMUM_CONTRAST_RATIO } = require('../support/theme-color.cjs');
+const {
+  TS022_THEME_PAYLOADS,
+  expectedColor,
+  expectedName,
+  expectedAccessibleName,
+  expectedGoalUrl,
+  expectedCodesFor,
+  sdgNumber,
+} = require('../support/sdg-catalog.cjs');
+
+// Tab presses allowed when walking to the badge. The fixture theme sits in the
+// first theme row, so the real walk is far shorter; this only stops the loop from
+// running forever if the badge is not reachable by keyboard at all.
+const MAX_TAB_PRESSES = 150;
+
+/** The theme row whose name cell reads exactly `themeName`. */
+async function themeRow(world, themeName) {
+  await page(world).getByTestId('theme-row').first().waitFor({ state: 'visible' });
+  for (const row of await page(world).getByTestId('theme-row').all()) {
+    if ((await row.getByTestId('theme-name').innerText()).trim() === themeName) return row;
+  }
+  assert.fail(`Expected a theme row named '${themeName}'`);
+}
+
+/** Every SDG badge rendered in that theme's SDG cell, in DOM order. */
+async function badgesOn(world, themeName) {
+  const row = await themeRow(world, themeName);
+  return row.getByTestId('theme-sdg').getByTestId('sdg-badge');
+}
+
+/** The single badge for `code` on `themeName`, failing when it is missing or duplicated. */
+async function badgeFor(world, themeName, code) {
+  const row = await themeRow(world, themeName);
+  const badge = row.getByTestId('theme-sdg').locator(`[data-testid="sdg-badge"][data-sdg-code="${code}"]`);
+  await badge.first().waitFor({ state: 'visible' });
+  assert.equal(await badge.count(), 1, `Expected exactly one '${code}' badge on theme '${themeName}'`);
+  return badge;
+}
+
+/**
+ * The badge's tooltip element.
+ *
+ * Matched on the role attribute rather than with getByRole: the tooltip is
+ * visibility:hidden until hover, which takes it out of the accessibility tree
+ * and therefore out of reach of a role query, and its hidden state is exactly
+ * what one of these steps has to assert.
+ */
+const tooltipOf = (badge) => badge.locator('[role="tooltip"]');
+
+/** The badge's rendered fill and its number's rendered text colour. */
+async function renderedColours(badge) {
+  const backgroundColor = await badge.evaluate((el) => getComputedStyle(el).backgroundColor);
+  const color = await badge.getByTestId('sdg-badge-number').evaluate((el) => getComputedStyle(el).color);
+  return { backgroundColor, color };
+}
+
+/** The computed properties a focus ring can be drawn with. */
+function readFocusIndicator(badge) {
+  return badge.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      outlineStyle: style.outlineStyle,
+      outlineWidth: style.outlineWidth,
+      outlineColor: style.outlineColor,
+      boxShadow: style.boxShadow,
+    };
+  });
+}
+
+function hasVisibleIndicator({ outlineStyle, outlineWidth, boxShadow }) {
+  const hasOutline = outlineStyle !== 'none' && outlineWidth !== '0px';
+  return hasOutline || (boxShadow !== 'none' && boxShadow !== '');
+}
+
+Given('I am authenticated in the browser as the TS-task-022 teacher', async function () {
+  await authenticateInBrowser(this, E2E_TEACHER_ID);
+});
+
+Given('the theme catalog contains only the TS-022 SDG fixtures', async function () {
+  await resetThemeCatalog(TS022_THEME_PAYLOADS);
+});
+
+Given('I am recording browser errors', async function () {
+  this.browserErrors = [];
+  const current = page(this);
+  current.on('pageerror', (error) => this.browserErrors.push(`uncaught: ${error.message}`));
+  current.on('console', (message) => {
+    if (message.type() === 'error') this.browserErrors.push(`console.error: ${message.text()}`);
+  });
+});
+
+Then('the theme {string} should show exactly {int} SDG badge(s)', async function (themeName, expectedCount) {
+  const badges = await badgesOn(this, themeName);
+  await badges.first().waitFor({ state: 'visible' });
+  assert.equal(
+    await badges.count(),
+    expectedCount,
+    `Expected ${expectedCount} SDG badge(s) on theme '${themeName}'`,
+  );
+});
+
+Then('the theme {string} should show no SDG badge', async function (themeName) {
+  assert.deepEqual(expectedCodesFor(themeName), [], `Fixture '${themeName}' must have no SDG code for this scenario`);
+  // The row itself is already rendered (themeRow waits for it), so a zero count
+  // here is a real absence rather than a not-yet-painted table.
+  const badges = await badgesOn(this, themeName);
+  assert.equal(await badges.count(), 0, `Expected no SDG badge on theme '${themeName}'`);
+});
+
+Then('the theme {string} should still render its name and description', async function (themeName) {
+  const row = await themeRow(this, themeName);
+  assert.equal((await row.getByTestId('theme-name').innerText()).trim(), themeName);
+  const description = (await row.getByTestId('theme-description').innerText()).trim();
+  assert.ok(description.length > 0, `Expected theme '${themeName}' to still show its description`);
+});
+
+Then('no browser error should have been recorded', function () {
+  assert.ok(Array.isArray(this.browserErrors), 'Expected browser error recording to have been started');
+  assert.deepEqual(this.browserErrors, [], `Expected no browser errors, got:\n  ${this.browserErrors.join('\n  ')}`);
+});
+
+Then('the SDG badge for {string} on theme {string} should show the number {string}', async function (code, themeName, expectedNumber) {
+  assert.equal(expectedNumber, String(sdgNumber(code)), `Scenario number must be the goal number of ${code}`);
+  const badge = await badgeFor(this, themeName, code);
+  assert.equal(
+    (await badge.getByTestId('sdg-badge-number').innerText()).trim(),
+    expectedNumber,
+    `Expected the '${code}' badge to show '${expectedNumber}'`,
+  );
+});
+
+Then('the SDG badge for {string} on theme {string} should be filled with {string}', async function (code, themeName, hex) {
+  // Guards the feature file against a typo: the literal must be the official colour.
+  assert.equal(hex.toUpperCase(), expectedColor(code), `Scenario colour for ${code} must match the official UN colour`);
+  const badge = await badgeFor(this, themeName, code);
+  const { backgroundColor } = await renderedColours(badge);
+  assert.equal(backgroundColor, hexToRgb(hex), `Expected the '${code}' badge to be filled with ${hex}`);
+});
+
+Then('every SDG badge on theme {string} should be filled with its official UN colour', async function (themeName) {
+  const badges = await badgesOn(this, themeName);
+  await badges.first().waitFor({ state: 'visible' });
+  const expectedCodes = expectedCodesFor(themeName);
+  const rendered = await badges.all();
+  assert.equal(rendered.length, expectedCodes.length, `Expected ${expectedCodes.length} badges on theme '${themeName}'`);
+
+  for (const [index, badge] of rendered.entries()) {
+    const code = await badge.getAttribute('data-sdg-code');
+    assert.equal(code, expectedCodes[index], `Expected badge ${index + 1} on '${themeName}' to be ${expectedCodes[index]}`);
+    const { backgroundColor } = await renderedColours(badge);
+    assert.equal(
+      backgroundColor,
+      hexToRgb(expectedColor(code)),
+      `Expected ${code} to be filled with its official UN colour ${expectedColor(code)}`,
+    );
+  }
+});
+
+Then('the tooltip of the SDG badge for {string} on theme {string} should be hidden', async function (code, themeName) {
+  const badge = await badgeFor(this, themeName, code);
+  const tooltip = tooltipOf(badge);
+  assert.equal(await tooltip.count(), 1, `Expected the '${code}' badge to carry a tooltip`);
+  assert.equal(await tooltip.isVisible(), false, `Expected the '${code}' tooltip to stay hidden until hover`);
+});
+
+When('I hover the SDG badge for {string} on theme {string}', async function (code, themeName) {
+  const badge = await badgeFor(this, themeName, code);
+  await badge.hover();
+  this.hoveredBadge = badge;
+  this.hoveredCode = code;
+});
+
+Then('the tooltip {string} should become visible', async function (expectedText) {
+  assert.ok(this.hoveredBadge, 'Expected a badge to have been hovered first');
+  assert.equal(expectedText, expectedName(this.hoveredCode), `Scenario tooltip must be the Dutch name of ${this.hoveredCode}`);
+  const tooltip = tooltipOf(this.hoveredBadge);
+  await tooltip.waitFor({ state: 'visible' });
+  assert.equal((await tooltip.innerText()).trim(), expectedText, 'Expected the tooltip to show the Dutch SDG name');
+});
+
+When('I click the SDG badge for {string} on theme {string}', async function (code, themeName) {
+  const context = page(this).context();
+  // Serve the UN goal page locally: the assertion is about where the badge points,
+  // and it should not depend on reaching sdgs.un.org from the test machine.
+  await context.route('https://sdgs.un.org/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>stubbed UN goal page</body></html>' }),
+  );
+
+  const badge = await badgeFor(this, themeName, code);
+  const [openedTab] = await Promise.all([context.waitForEvent('page'), badge.click()]);
+  await openedTab.waitForLoadState('domcontentloaded');
+  this.openedTab = openedTab;
+  this.clickedCode = code;
+});
+
+Then('a new browser tab should have opened at {string}', async function (expectedUrl) {
+  assert.ok(this.openedTab, 'Expected the click to have opened a new browser tab');
+  assert.equal(expectedUrl, expectedGoalUrl(this.clickedCode), `Scenario URL must be the UN goal page for ${this.clickedCode}`);
+  assert.notEqual(this.openedTab, page(this), 'Expected a new tab, not a navigation of the current one');
+  assert.equal(this.openedTab.url(), expectedUrl, 'Expected the new tab to be on the UN goal page');
+  assert.ok(page(this).url().includes('/teacher'), 'Expected the original tab to stay on the teacher page');
+});
+
+Then('the SDG badges on theme {string} should be {string} and {string} in that order', async function (themeName, firstCode, secondCode) {
+  const badges = await badgesOn(this, themeName);
+  await badges.first().waitFor({ state: 'visible' });
+  const renderedCodes = await Promise.all((await badges.all()).map((badge) => badge.getAttribute('data-sdg-code')));
+  assert.deepEqual(renderedCodes, [firstCode, secondCode], `Expected '${themeName}' to render ${firstCode} then ${secondCode}`);
+});
+
+Then('each SDG badge on theme {string} should carry its own colour, tooltip and goal link', async function (themeName) {
+  const badges = await badgesOn(this, themeName);
+  await badges.first().waitFor({ state: 'visible' });
+  const rendered = await badges.all();
+  assert.equal(rendered.length, expectedCodesFor(themeName).length, `Expected every fixture code on '${themeName}' to render`);
+
+  for (const badge of rendered) {
+    const code = await badge.getAttribute('data-sdg-code');
+    const { backgroundColor } = await renderedColours(badge);
+    assert.equal(backgroundColor, hexToRgb(expectedColor(code)), `Expected ${code} to carry its own UN colour`);
+
+    // The tooltip is hidden until hover, so read its text rather than its visibility.
+    const tooltipText = (await tooltipOf(badge).textContent())?.trim();
+    assert.equal(tooltipText, expectedName(code), `Expected ${code} to carry its own Dutch tooltip`);
+
+    assert.equal(await badge.getAttribute('href'), expectedGoalUrl(code), `Expected ${code} to link to its own UN goal page`);
+    assert.equal(await badge.getAttribute('target'), '_blank', `Expected ${code} to open in a new tab`);
+  }
+});
+
+Then('the SDG badge for {string} on theme {string} should have text colour {string}', async function (code, themeName, hex) {
+  const badge = await badgeFor(this, themeName, code);
+  const { color, backgroundColor } = await renderedColours(badge);
+  assert.equal(color, hexToRgb(hex), `Expected the '${code}' badge number to be rendered in ${hex}`);
+
+  // Legibility is the point of AC-7, so prove the pairing actually reads, not just
+  // that it matches the colour the scenario named.
+  const ratio = contrastRatio(parseCssColor(color).channels, parseCssColor(backgroundColor).channels);
+  assert.ok(
+    ratio >= MINIMUM_CONTRAST_RATIO,
+    `Expected ${code} text ${hex} on ${expectedColor(code)} to clear WCAG AA, got ${ratio.toFixed(2)}:1`,
+  );
+});
+
+Then('every SDG badge on theme {string} should meet WCAG AA contrast', async function (themeName) {
+  const badges = await badgesOn(this, themeName);
+  await badges.first().waitFor({ state: 'visible' });
+  const rendered = await badges.all();
+  assert.equal(rendered.length, expectedCodesFor(themeName).length, `Expected every fixture code on '${themeName}' to render`);
+
+  const failures = [];
+  for (const badge of rendered) {
+    const code = await badge.getAttribute('data-sdg-code');
+    const { color, backgroundColor } = await renderedColours(badge);
+    const ratio = contrastRatio(parseCssColor(color).channels, parseCssColor(backgroundColor).channels);
+    if (ratio < MINIMUM_CONTRAST_RATIO) failures.push(`${code}: ${color} on ${backgroundColor} = ${ratio.toFixed(2)}:1`);
+  }
+  assert.deepEqual(failures, [], `Expected every SDG badge to clear ${MINIMUM_CONTRAST_RATIO}:1:\n  ${failures.join('\n  ')}`);
+});
+
+Then('the SDG badge for {string} on theme {string} should be a link announced as {string}', async function (code, themeName, accessibleName) {
+  assert.equal(accessibleName, expectedAccessibleName(code), `Scenario name must be the full accessible name of ${code}`);
+  const row = await themeRow(this, themeName);
+  // getByRole resolves the computed accessible name, so this fails if the badge is
+  // not exposed as a link or is announced as anything other than the full SDG name.
+  const link = row.getByTestId('theme-sdg').getByRole('link', { name: accessibleName, exact: true });
+  await link.waitFor({ state: 'visible' });
+  assert.equal(await link.count(), 1, `Expected one link announced as '${accessibleName}'`);
+  assert.equal(await link.getAttribute('data-sdg-code'), code, 'Expected that link to be the SDG badge itself');
+  this.lastAnnouncedBadge = link;
+});
+
+Then('the number inside that badge should be hidden from assistive technology', async function () {
+  assert.ok(this.lastAnnouncedBadge, 'Expected a badge to have been resolved by the preceding step');
+  assert.equal(
+    await this.lastAnnouncedBadge.getByTestId('sdg-badge-number').getAttribute('aria-hidden'),
+    'true',
+    'Expected the visual number to be hidden from screen readers, so only the full SDG name is announced',
+  );
+});
+
+When('I tab forwards until the SDG badge for {string} on theme {string} has focus', async function (code, themeName) {
+  const badge = await badgeFor(this, themeName, code);
+  this.unfocusedIndicator = await readFocusIndicator(badge);
+
+  let isFocused = false;
+  for (let press = 0; press < MAX_TAB_PRESSES && !isFocused; press += 1) {
+    await page(this).keyboard.press('Tab');
+    isFocused = await badge.evaluate((el) => el === document.activeElement);
+  }
+  assert.ok(isFocused, `Expected the '${code}' badge to be reachable within ${MAX_TAB_PRESSES} Tab presses`);
+  this.focusedBadge = badge;
+});
+
+Then('that SDG badge should show a focus indicator it does not show when unfocused', async function () {
+  assert.ok(this.focusedBadge, 'Expected a badge to have been focused by the preceding step');
+  const focused = await readFocusIndicator(this.focusedBadge);
+  assert.ok(
+    hasVisibleIndicator(focused),
+    `Expected a focus ring while focused, computed styles were ${JSON.stringify(focused)}`,
+  );
+  assert.notDeepEqual(
+    focused,
+    this.unfocusedIndicator,
+    'Expected the focus indicator to appear on focus rather than being present all the time',
+  );
+});

--- a/tests/e2e/steps/ts-task-023-sdg-badge-integration.steps.cjs
+++ b/tests/e2e/steps/ts-task-023-sdg-badge-integration.steps.cjs
@@ -1,0 +1,237 @@
+// TS-task-023 - SDG badge integration across the theme surfaces.
+//
+// This suite proves the SdgBadge (TS-task-022) is wired into every remaining theme
+// surface. It reuses the navigation and staging steps of the sibling suites through
+// Cucumber's global step registry - the TS-022 teacher catalog steps, the TS-019
+// per-project link staging and details-page open, and the TS-018 card/public-page
+// open - and defines only the SDG-badge assertions those suites do not carry.
+//
+// Expected SDG colours, names and goal URLs come from support/sdg-catalog.cjs, which
+// hardcodes them from the issue rather than importing utils/sdg.js, so these steps
+// answer to the specification instead of to the code under test.
+//
+// The badge is a link (SdgBadge default) on the surfaces where a link is safe -
+// the ThemePicker pills and the details pills, where it sits ADJACENT to its pill -
+// and a passive indicator on the project cards, where the card is a single <Link>
+// and a nested <a> would be invalid HTML. Each assertion checks the shape the
+// surface is meant to have, not just that some badge rendered.
+
+const assert = require('node:assert/strict');
+
+const { Given, When, Then } = require('@qavajs/core');
+
+const { FRONTEND_URL, PROOF_PROJECT_ID } = require('../support/test-data.cjs');
+const { page } = require('../support/e2e-session.cjs');
+const { fetchThemes } = require('../support/theme-catalog.cjs');
+const { stubThemesEndpoint } = require('../support/theme-stub.cjs');
+const { hexToRgb } = require('../support/theme-color.cjs');
+const { expectedColor, expectedGoalUrl, sdgNumber } = require('../support/sdg-catalog.cjs');
+
+const PICKER_HARNESS_PATH = '/dev/theme-picker';
+
+// --- shared element helpers ------------------------------------------------------
+
+/** A theme catalog row whose name cell reads exactly `name`. */
+async function themeRowByName(world, name) {
+  await page(world).getByTestId('theme-row').first().waitFor({ state: 'visible' });
+  for (const row of await page(world).getByTestId('theme-row').all()) {
+    if ((await row.getByTestId('theme-name').innerText()).trim() === name) return row;
+  }
+  return assert.fail(`Expected a theme row named '${name}'`);
+}
+
+/** Resolve a catalog theme name to the id the backend assigned it. */
+async function themeIdByName(name) {
+  const catalog = await fetchThemes();
+  const theme = catalog.find((candidate) => candidate?.name === name);
+  assert.ok(theme?.id, `Expected a theme named '${name}' in the catalog`);
+  return theme.id;
+}
+
+/** The SdgBadge for `code` under `scope`, asserting it renders exactly once. */
+async function sdgBadge(scope, code) {
+  const badge = scope.locator(`[data-testid="sdg-badge"][data-sdg-code="${code}"]`);
+  await badge.first().waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await badge.count(), 1, `Expected exactly one '${code}' SDG badge`);
+  return badge;
+}
+
+/** Assert a badge is a link to its own UN goal page, opening in a new tab. */
+async function assertGoalLink(badge, urlCode) {
+  assert.equal(await badge.evaluate((el) => el.tagName), 'A', `Expected the '${urlCode}' SDG badge to be a link`);
+  assert.equal(await badge.getAttribute('href'), expectedGoalUrl(urlCode), `Expected the '${urlCode}' SDG badge to link to its UN goal page`);
+  assert.equal(await badge.getAttribute('target'), '_blank', `Expected the '${urlCode}' SDG badge to open in a new tab`);
+}
+
+// --- AC-1: the teacher theme management list ------------------------------------
+
+Then('the theme row {string} shows its SDG badge for {string} beside the theme name', async function (themeName, code) {
+  const row = await themeRowByName(this, themeName);
+  // The name cell and the SDG cell share the same row, so a badge found within this
+  // row is rendered beside the name (the SDG column sits right after the Naam column).
+  assert.equal((await row.getByTestId('theme-name').innerText()).trim(), themeName);
+  await sdgBadge(row, code);
+});
+
+// --- AC-2: the SDG picker inside the create/edit modal --------------------------
+
+function createModal(world) {
+  return page(world).getByTestId('theme-create-modal');
+}
+
+When('I open the SDG code dropdown', async function () {
+  await createModal(this).getByTestId('theme-sdg-trigger').click();
+});
+
+Then('the SDG option {string} shows a UN colour preview filled with {string}', async function (code, hex) {
+  // Guard the feature literal against a typo: it must be the official UN colour.
+  assert.equal(hex.toUpperCase(), expectedColor(code), `Scenario colour for ${code} must be its official UN colour`);
+  const swatch = createModal(this).getByTestId(`theme-sdg-swatch-${code}`);
+  await swatch.first().waitFor({ state: 'attached', timeout: 10_000 });
+  const background = await swatch.first().evaluate((el) => getComputedStyle(el).backgroundColor);
+  assert.equal(background, hexToRgb(hex), `Expected the ${code} option's colour preview to be filled with ${hex}`);
+});
+
+Then('the SDG option {string} still reads {string}', async function (code, expectedText) {
+  const option = createModal(this).getByTestId(`theme-sdg-option-${code}`);
+  const text = (await option.innerText()).replace(/\s+/g, ' ').trim();
+  assert.ok(text.includes(expectedText), `Expected the ${code} option to still read '${expectedText}', got '${text}'`);
+});
+
+Then('every SDG option shows a UN colour preview in its own official UN colour', async function () {
+  const modal = createModal(this);
+  for (let number = 1; number <= 17; number += 1) {
+    const code = `SDG${number}`;
+    const swatch = modal.getByTestId(`theme-sdg-swatch-${code}`);
+    assert.equal(await swatch.count(), 1, `Expected a colour preview for ${code}`);
+    const background = await swatch.evaluate((el) => getComputedStyle(el).backgroundColor);
+    assert.equal(
+      background,
+      hexToRgb(expectedColor(code)),
+      `Expected the ${code} colour preview to show its official UN colour ${expectedColor(code)}`,
+    );
+  }
+});
+
+// --- AC-3: the ThemePicker pills (driven through the dev harness) ----------------
+
+Given('the theme picker lists a theme {string} with SDG code {string} and a theme {string} with no SDG code', async function (themedName, code, plainName) {
+  // Guard the feature literal so a typo cannot silently pick an unknown code.
+  sdgNumber(code);
+  this.pickerThemes = [
+    { id: 'ts023-picker-themed', name: themedName, color: '#4CAF50', sdg_code: code },
+    { id: 'ts023-picker-plain', name: plainName, color: '#9E9E9E' },
+  ];
+  await stubThemesEndpoint(page(this), { body: this.pickerThemes });
+});
+
+When('I open the SDG-themed theme picker demo', async function () {
+  await page(this).goto(`${FRONTEND_URL}${PICKER_HARNESS_PATH}`);
+  await page(this).getByTestId('theme-picker').waitFor({ state: 'visible', timeout: 15_000 });
+});
+
+/** The per-theme group (pill + optional badge) the picker renders for `name`. */
+function pickerGroup(world, name) {
+  const theme = (world.pickerThemes || []).find((candidate) => candidate.name === name);
+  assert.ok(theme, `Unknown picker theme '${name}' - stage it in the Given first`);
+  return page(world).locator(`[data-testid="theme-pill-group"][data-theme-id="${theme.id}"]`);
+}
+
+Then('the theme picker pill {string} shows an adjacent SDG badge for {string}', async function (name, code) {
+  const group = pickerGroup(this, name);
+  await group.getByTestId('theme-pill').waitFor({ state: 'visible', timeout: 12_000 });
+  await sdgBadge(group, code);
+});
+
+Then('the picker SDG badge for {string} links to the UN goal page for {string}', async function (code, urlCode) {
+  const badge = page(this).locator(`[data-testid="theme-pill-group"] [data-testid="sdg-badge"][data-sdg-code="${code}"]`).first();
+  await badge.waitFor({ state: 'visible', timeout: 12_000 });
+  await assertGoalLink(badge, urlCode);
+});
+
+Then('the theme picker pill {string} shows no SDG badge', async function (name) {
+  const group = pickerGroup(this, name);
+  await group.getByTestId('theme-pill').waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await group.getByTestId('sdg-badge').count(), 0, `Expected no SDG badge beside the '${name}' pill`);
+});
+
+// --- AC-4 / AC-6: the project details theme section -----------------------------
+
+/** The per-theme group (pill + optional badge) the details section renders for `name`. */
+async function detailsGroup(world, name) {
+  const id = await themeIdByName(name);
+  return page(world).getByTestId('project-themes').locator(`[data-testid="project-theme"][data-theme-id="${id}"]`);
+}
+
+Then('the project theme pill {string} shows an adjacent SDG badge for {string}', async function (name, code) {
+  const group = await detailsGroup(this, name);
+  await group.getByTestId('project-theme-pill').waitFor({ state: 'visible', timeout: 12_000 });
+  await sdgBadge(group, code);
+});
+
+Then('the details SDG badge for {string} links to the UN goal page for {string}', async function (code, urlCode) {
+  const badge = page(this).getByTestId('project-themes').locator(`[data-testid="sdg-badge"][data-sdg-code="${code}"]`).first();
+  await badge.waitFor({ state: 'visible', timeout: 12_000 });
+  await assertGoalLink(badge, urlCode);
+});
+
+Then('the project theme pill {string} shows no SDG badge', async function (name) {
+  const group = await detailsGroup(this, name);
+  await group.getByTestId('project-theme-pill').waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await group.getByTestId('sdg-badge').count(), 0, `Expected no SDG badge beside the '${name}' pill`);
+});
+
+// --- AC-5 / AC-6: the project cards ---------------------------------------------
+
+function projectCard(world) {
+  return page(world).locator(`#project-${PROOF_PROJECT_ID}`);
+}
+
+function publicProjectCard(world) {
+  return page(world).locator(`a[href="/publiek/${PROOF_PROJECT_ID}"]`);
+}
+
+Then('the project card theme badge shows an SDG badge for {string}', async function (code) {
+  const card = projectCard(this);
+  await card.getByTestId('project-theme-badge').waitFor({ state: 'visible', timeout: 12_000 });
+  await sdgBadge(card, code);
+});
+
+Then('the public project card theme badge shows an SDG badge for {string}', async function (code) {
+  const card = publicProjectCard(this);
+  await card.getByTestId('project-theme-badge').waitFor({ state: 'visible', timeout: 12_000 });
+  await sdgBadge(card, code);
+});
+
+Then('the project card SDG badge is a passive indicator, not a link', async function () {
+  const badge = projectCard(this).getByTestId('sdg-badge').first();
+  await badge.waitFor({ state: 'visible', timeout: 12_000 });
+  // Inside the card's own <Link>, a nested <a> would be invalid HTML, so the card
+  // badge must be a passive element carrying no href of its own.
+  assert.notEqual(await badge.evaluate((el) => el.tagName), 'A', 'Expected the card SDG badge not to be a nested <a>');
+  assert.equal(await badge.getAttribute('href'), null, 'Expected the card SDG badge to carry no href');
+});
+
+Then('the project card theme badge shows no SDG badge', async function () {
+  const card = projectCard(this);
+  await card.getByTestId('project-theme-badge').waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await card.getByTestId('sdg-badge').count(), 0, 'Expected no SDG badge on the project card');
+});
+
+Then('the project card shows exactly {int} SDG badges', async function (count) {
+  const card = projectCard(this);
+  await card.getByTestId('project-theme-badge').waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await card.getByTestId('sdg-badge').count(), count, `Expected exactly ${count} SDG badge(s) on the card`);
+});
+
+Then('the project card SDG badge shows an overflow count of {string}', async function (expected) {
+  const overflow = projectCard(this).getByTestId('sdg-badge-overflow');
+  await overflow.waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal((await overflow.innerText()).trim(), expected, `Expected the card SDG overflow to read '${expected}'`);
+});
+
+Then('the project card SDG badges show no overflow count', async function () {
+  const card = projectCard(this);
+  await card.getByTestId('project-theme-badge').waitFor({ state: 'visible', timeout: 12_000 });
+  assert.equal(await card.getByTestId('sdg-badge-overflow').count(), 0, 'Expected no +N SDG overflow on the card');
+});

--- a/tests/e2e/support/sdg-catalog.cjs
+++ b/tests/e2e/support/sdg-catalog.cjs
@@ -82,11 +82,15 @@ const expectedGoalUrl = (code) => `https://sdgs.un.org/goals/goal${sdgNumber(cod
 //   SDG Licht         light fill (SDG7)      AC-7
 //   SDG Alle          all 17 codes at once   AC-2, AC-7 (contrast sweep)
 //   SDG Geen          no sdg_code at all     AC-6
+//   SDG Dubbel        the same code twice    AC-5 (repeat)
 //
 // "SDG Enkel" carries display_order 1 so it renders in the first theme row: the
 // keyboard-focus scenario tabs to it from the top of the page, and a first row
 // keeps that walk short. Omitting sdg_code entirely on "SDG Geen" is what sends
 // a null sdgCode into the component, which is exactly what AC-6 is about.
+//
+// "SDG Dubbel" is not a typo: the backend's code pattern is SDG<n>(,SDG<n>)*,
+// which accepts a repeat, so 'SDG12,SDG12' is data the badge can really be handed.
 const TS022_THEME_FIXTURES = Object.freeze([
   Object.freeze({ name: 'SDG Enkel', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Eén SDG-code.' }),
   Object.freeze({ name: 'SDG Samengesteld', sdg_code: 'SDG2,SDG12', icon: 'restaurant', color: '#FF9800', display_order: 2, description: 'Twee SDG-codes.' }),
@@ -94,6 +98,7 @@ const TS022_THEME_FIXTURES = Object.freeze([
   Object.freeze({ name: 'SDG Licht', sdg_code: 'SDG7', icon: 'bolt', color: '#FFC107', display_order: 4, description: 'Lichte SDG-kleur.' }),
   Object.freeze({ name: 'SDG Alle', sdg_code: ALL_SDG_CODES.join(','), icon: 'public', color: '#2196F3', display_order: 5, description: 'Alle zeventien SDG-codes.' }),
   Object.freeze({ name: 'SDG Geen', sdg_code: null, icon: 'category', color: '#9E9E9E', display_order: 6, description: 'Geen SDG-code.' }),
+  Object.freeze({ name: 'SDG Dubbel', sdg_code: 'SDG12,SDG12', icon: 'content_copy', color: '#795548', display_order: 7, description: 'Dezelfde SDG-code twee keer.' }),
 ]);
 
 /** The fixture themes as the theme API accepts them: a null sdg_code is omitted, not sent. */
@@ -101,18 +106,22 @@ const TS022_THEME_PAYLOADS = Object.freeze(
   TS022_THEME_FIXTURES.map(({ sdg_code: sdgCode, ...rest }) => Object.freeze(sdgCode ? { ...rest, sdg_code: sdgCode } : rest)),
 );
 
-/** The codes a fixture theme must render badges for, in order; [] when it has none. */
+/**
+ * The codes a fixture theme must render badges for, in order; [] when it has none.
+ *
+ * Distinct codes, because a badge stands for a goal: naming SDG12 twice is still
+ * one goal, so "SDG Dubbel" expects one badge and not two.
+ */
 function expectedCodesFor(themeName) {
   const fixture = TS022_THEME_FIXTURES.find((theme) => theme.name === themeName);
   assert.ok(fixture, `Expected a TS-task-022 fixture theme named '${themeName}'`);
-  return fixture.sdg_code ? fixture.sdg_code.split(',') : [];
+  return fixture.sdg_code ? [...new Set(fixture.sdg_code.split(','))] : [];
 }
 
+// Only what the steps actually consume. The colour/name tables and the fixture
+// list stay module-private: they are reached through the expected* helpers, which
+// fail loudly on a code the tables do not know.
 module.exports = {
-  SDG_COLORS,
-  SDG_NAMES_NL,
-  ALL_SDG_CODES,
-  TS022_THEME_FIXTURES,
   TS022_THEME_PAYLOADS,
   sdgNumber,
   expectedColor,

--- a/tests/e2e/support/sdg-catalog.cjs
+++ b/tests/e2e/support/sdg-catalog.cjs
@@ -1,0 +1,123 @@
+// Expected SDG data and the theme fixtures for the TS-task-022 badge suite.
+//
+// The 17 official UN colours and their Dutch names are spelled out here straight
+// from the GitHub issue (TS-task-022 AC-2 and the Technical Notes), deliberately
+// NOT imported from projojo_frontend/src/utils/sdg.js. A step that read the
+// colours out of the code under test would only prove that file agrees with
+// itself; hardcoding the expectation is what makes "the badge uses the official
+// UN colour" an assertion rather than a tautology. This mirrors the same choice
+// theme-color.cjs makes about the WCAG maths.
+
+const assert = require('node:assert/strict');
+
+/** Official UN SDG colours, keyed by goal number (TS-task-022 AC-2). */
+const SDG_COLORS = Object.freeze({
+  1: '#E5243B',
+  2: '#DDA63A',
+  3: '#4C9F38',
+  4: '#C5192D',
+  5: '#FF3A21',
+  6: '#26BDE2',
+  7: '#FCC30B',
+  8: '#A21942',
+  9: '#FD6925',
+  10: '#DD1367',
+  11: '#FD9D24',
+  12: '#BF8B2E',
+  13: '#3F7E44',
+  14: '#0A97D9',
+  15: '#56C02B',
+  16: '#00689D',
+  17: '#19486A',
+});
+
+/** Dutch SDG names, keyed by goal number (TS-task-022 AC-3 and Technical Notes). */
+const SDG_NAMES_NL = Object.freeze({
+  1: 'Geen armoede',
+  2: 'Geen honger',
+  3: 'Goede gezondheid en welzijn',
+  4: 'Kwaliteitsonderwijs',
+  5: 'Gendergelijkheid',
+  6: 'Schoon water en sanitair',
+  7: 'Betaalbare en duurzame energie',
+  8: 'Waardig werk en economische groei',
+  9: 'Industrie, innovatie en infrastructuur',
+  10: 'Ongelijkheid verminderen',
+  11: 'Duurzame steden en gemeenschappen',
+  12: 'Verantwoorde consumptie en productie',
+  13: 'Klimaatactie',
+  14: 'Leven in het water',
+  15: 'Leven op het land',
+  16: 'Vrede, justitie en sterke instellingen',
+  17: 'Partnerschap om doelstellingen te bereiken',
+});
+
+/** Every code SDG1..SDG17, in canonical order. */
+const ALL_SDG_CODES = Object.freeze(Object.keys(SDG_COLORS).map((number) => `SDG${number}`));
+
+/** 'SDG12' -> 12, failing loudly on anything the fixtures did not intend. */
+function sdgNumber(code) {
+  const match = /^SDG(\d+)$/.exec(code);
+  assert.ok(match, `Expected an SDG code like 'SDG12', got '${code}'`);
+  const number = Number(match[1]);
+  assert.ok(SDG_COLORS[number], `Expected a known SDG number in '${code}'`);
+  return number;
+}
+
+const expectedColor = (code) => SDG_COLORS[sdgNumber(code)];
+const expectedName = (code) => SDG_NAMES_NL[sdgNumber(code)];
+
+/** The full accessible name AC-8 requires, e.g. 'SDG 12: Verantwoorde consumptie en productie'. */
+const expectedAccessibleName = (code) => `SDG ${sdgNumber(code)}: ${expectedName(code)}`;
+
+/** The UN goal page AC-4 requires the badge to link to. */
+const expectedGoalUrl = (code) => `https://sdgs.un.org/goals/goal${sdgNumber(code)}`;
+
+// Theme fixtures for the TS-task-022 scenarios. Each theme isolates one badge
+// behaviour, so a scenario never depends on another scenario's theme:
+//
+//   SDG Enkel         single code            AC-1, AC-3, AC-4, AC-8
+//   SDG Samengesteld  compound code          AC-5
+//   SDG Donker        dark fill  (SDG17)     AC-7
+//   SDG Licht         light fill (SDG7)      AC-7
+//   SDG Alle          all 17 codes at once   AC-2, AC-7 (contrast sweep)
+//   SDG Geen          no sdg_code at all     AC-6
+//
+// "SDG Enkel" carries display_order 1 so it renders in the first theme row: the
+// keyboard-focus scenario tabs to it from the top of the page, and a first row
+// keeps that walk short. Omitting sdg_code entirely on "SDG Geen" is what sends
+// a null sdgCode into the component, which is exactly what AC-6 is about.
+const TS022_THEME_FIXTURES = Object.freeze([
+  Object.freeze({ name: 'SDG Enkel', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Eén SDG-code.' }),
+  Object.freeze({ name: 'SDG Samengesteld', sdg_code: 'SDG2,SDG12', icon: 'restaurant', color: '#FF9800', display_order: 2, description: 'Twee SDG-codes.' }),
+  Object.freeze({ name: 'SDG Donker', sdg_code: 'SDG17', icon: 'handshake', color: '#3F51B5', display_order: 3, description: 'Donkere SDG-kleur.' }),
+  Object.freeze({ name: 'SDG Licht', sdg_code: 'SDG7', icon: 'bolt', color: '#FFC107', display_order: 4, description: 'Lichte SDG-kleur.' }),
+  Object.freeze({ name: 'SDG Alle', sdg_code: ALL_SDG_CODES.join(','), icon: 'public', color: '#2196F3', display_order: 5, description: 'Alle zeventien SDG-codes.' }),
+  Object.freeze({ name: 'SDG Geen', sdg_code: null, icon: 'category', color: '#9E9E9E', display_order: 6, description: 'Geen SDG-code.' }),
+]);
+
+/** The fixture themes as the theme API accepts them: a null sdg_code is omitted, not sent. */
+const TS022_THEME_PAYLOADS = Object.freeze(
+  TS022_THEME_FIXTURES.map(({ sdg_code: sdgCode, ...rest }) => Object.freeze(sdgCode ? { ...rest, sdg_code: sdgCode } : rest)),
+);
+
+/** The codes a fixture theme must render badges for, in order; [] when it has none. */
+function expectedCodesFor(themeName) {
+  const fixture = TS022_THEME_FIXTURES.find((theme) => theme.name === themeName);
+  assert.ok(fixture, `Expected a TS-task-022 fixture theme named '${themeName}'`);
+  return fixture.sdg_code ? fixture.sdg_code.split(',') : [];
+}
+
+module.exports = {
+  SDG_COLORS,
+  SDG_NAMES_NL,
+  ALL_SDG_CODES,
+  TS022_THEME_FIXTURES,
+  TS022_THEME_PAYLOADS,
+  sdgNumber,
+  expectedColor,
+  expectedName,
+  expectedAccessibleName,
+  expectedGoalUrl,
+  expectedCodesFor,
+};


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds SDG badges across theme and project surfaces and extends nested backend theme data with `sdg_code`.
- Adds reusable SDG parsing, catalog, badge rendering, colors, labels, and goal links.
- Integrates SDG indicators into theme management, pickers, project details, and project cards.
- Extends TypeDB projections and repository mappings to expose SDG codes.
- Adds end-to-end coverage for badge behavior and integration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| projojo_frontend/src/components/SdgBadge.jsx | Introduces accessible interactive and passive SDG badge variants consistent with their embedding contexts. |
| projojo_frontend/src/utils/sdg.js | Centralizes the SDG catalog and canonical parsing, joining, validation, and deduplication behavior. |
| projojo_frontend/src/components/ProjectThemeBadge.jsx | Adds bounded passive SDG indicators to linked project cards without introducing nested links. |
| projojo_frontend/src/components/ProjectThemeSection.jsx | Adds adjacent interactive SDG links to project-detail theme pills while keeping controls outside live regions. |
| projojo_frontend/src/components/ThemePicker.jsx | Groups each theme pill with an adjacent SDG link without nesting links inside selection controls. |
| projojo_backend/domain/repositories/business_repository.py | Projects and safely flattens optional SDG codes in nested business project themes. |
| projojo_backend/domain/repositories/project_repository.py | Propagates optional SDG codes through public and business-scoped project theme mappings. |

</details>

<sub>Reviews (2): Last reviewed commit: ["follow up ai review ts-023"](https://github.com/han-aim-cmd-wg/projojo/commit/b8b258c6d3e0dbb57ec9f5a1cf4af37ce9453dd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52554342)</sub>

<!-- /greptile_comment -->