### PR TITLE
Duplicate sdg code rejection

### DIFF
--- a/projojo_backend/service/validation_service.py
+++ b/projojo_backend/service/validation_service.py
@@ -2,6 +2,7 @@ import re
 
 THEME_NAME_VALIDATION_ERROR = "Naam is verplicht en mag maximaal 100 tekens zijn"
 THEME_SDG_CODE_VALIDATION_ERROR = "Ongeldig SDG-code formaat. Gebruik bijv. 'SDG1' of 'SDG12,SDG4'"
+THEME_SDG_CODE_DUPLICATE_ERROR = "SDG-codes mogen niet dubbel voorkomen"
 THEME_COLOR_VALIDATION_ERROR = "Ongeldige kleurcode. Gebruik hex-formaat zoals '#4CAF50'"
 THEME_ICON_VALIDATION_ERROR = "Icoon naam mag maximaal 50 tekens zijn"
 THEME_DESCRIPTION_VALIDATION_ERROR = "Beschrijving mag maximaal 500 tekens zijn"
@@ -65,6 +66,16 @@ def validate_theme(theme, require_name: bool = False) -> None:
     if "sdg_code" in fields_set and theme.sdg_code:
         if not re.fullmatch(r"SDG([1-9]|1[0-7])(,SDG([1-9]|1[0-7]))*", theme.sdg_code):
             raise ValueError(THEME_SDG_CODE_VALIDATION_ERROR)
+
+        # A theme's SDG codes are a set: naming the same goal twice says nothing
+        # extra, so "SDG12,SDG12" is rejected rather than stored as a second way
+        # of writing "SDG12". "No repeated group" is not expressible in the
+        # pattern above without enumerating every pair, hence a separate check -
+        # and a separate message, so a repeat is not reported as a format error.
+        # Order stays untouched: it is plausibly meaningful (primary SDG first).
+        codes = theme.sdg_code.split(",")
+        if len(set(codes)) != len(codes):
+            raise ValueError(THEME_SDG_CODE_DUPLICATE_ERROR)
 
     if "color" in fields_set and theme.color is not None:
         if not re.fullmatch(r"#[0-9A-Fa-f]{6}", theme.color):

--- a/projojo_backend/service/validation_service.py
+++ b/projojo_backend/service/validation_service.py
@@ -67,12 +67,10 @@ def validate_theme(theme, require_name: bool = False) -> None:
         if not re.fullmatch(r"SDG([1-9]|1[0-7])(,SDG([1-9]|1[0-7]))*", theme.sdg_code):
             raise ValueError(THEME_SDG_CODE_VALIDATION_ERROR)
 
-        # A theme's SDG codes are a set: naming the same goal twice says nothing
-        # extra, so "SDG12,SDG12" is rejected rather than stored as a second way
-        # of writing "SDG12". "No repeated group" is not expressible in the
-        # pattern above without enumerating every pair, hence a separate check -
-        # and a separate message, so a repeat is not reported as a format error.
-        # Order stays untouched: it is plausibly meaningful (primary SDG first).
+        # "No repeated group" is not expressible in the pattern above without
+        # enumerating every pair, so uniqueness is a separate check - with its own
+        # message, so a repeat is not reported as a format error. The value is
+        # stored verbatim; nothing here reorders it.
         codes = theme.sdg_code.split(",")
         if len(set(codes)) != len(codes):
             raise ValueError(THEME_SDG_CODE_DUPLICATE_ERROR)

--- a/projojo_frontend/src/components/ProjectThemeBadge.jsx
+++ b/projojo_frontend/src/components/ProjectThemeBadge.jsx
@@ -38,8 +38,7 @@ export default function ProjectThemeBadge({ themes }) {
     //
     // Counts are taken from parseSdgGoals - the deduped, valid-only list SdgBadge itself
     // renders - so the badge count and the "+N" count can never disagree. A repeated code
-    // (e.g. "SDG12,SDG12", still accepted by the backend until TS-task-028) is one goal,
-    // one badge, and is not miscounted into the overflow.
+    // is one goal and one badge, and is not miscounted into the overflow.
     const goals = parseSdgGoals(theme.sdg_code);
     const shownSdgCodes = goals.slice(0, CARD_SDG_BADGE_LIMIT).map((goal) => `SDG${goal.number}`);
     const hiddenSdgCount = goals.length - shownSdgCodes.length;

--- a/projojo_frontend/src/utils/sdg.js
+++ b/projojo_frontend/src/utils/sdg.js
@@ -48,10 +48,11 @@ export function parseSdgCodes(sdgCode) {
 /**
  * The distinct goals a stored sdg_code names, in stored order.
  *
- * The backend's pattern is SDG<n>(,SDG<n>)*, which accepts the same goal twice,
- * so "SDG12,SDG12" is real data — and one goal is still one badge however often
- * it is named. Deduplicating here is also what keeps the goal number usable as a
- * React key.
+ * One goal is one badge however often it is named, so a repeated code collapses
+ * rather than rendering twice. TS-task-028 rejects repeats on write, making this
+ * defensive rather than load-bearing; it stays because a display component should
+ * not duplicate on data it is handed, and because deduplicating is what keeps the
+ * goal number usable as a React key.
  *
  * A null or empty code yields an empty list. So does an unrecognised one, which
  * the backend's pattern already rules out; dropping it keeps this function total

--- a/projojo_frontend/src/utils/sdg.js
+++ b/projojo_frontend/src/utils/sdg.js
@@ -49,10 +49,10 @@ export function parseSdgCodes(sdgCode) {
  * The distinct goals a stored sdg_code names, in stored order.
  *
  * One goal is one badge however often it is named, so a repeated code collapses
- * rather than rendering twice. TS-task-028 rejects repeats on write, making this
- * defensive rather than load-bearing; it stays because a display component should
- * not duplicate on data it is handed, and because deduplicating is what keeps the
- * goal number usable as a React key.
+ * rather than rendering twice, and deduplicating is what keeps the goal number
+ * usable as a React key. TS-task-028 rejects repeats on write, but the seeds write
+ * sdgCode as raw TypeQL past that validation and the schema constrains nothing, so
+ * a repeated code is still data this can be handed.
  *
  * A null or empty code yields an empty list. So does an unrecognised one, which
  * the backend's pattern already rules out; dropping it keeps this function total

--- a/tests/e2e/features/ts-task-022-sdg-badge-component.feature
+++ b/tests/e2e/features/ts-task-022-sdg-badge-component.feature
@@ -49,16 +49,6 @@ Feature: TS-task-022 SDG badge component with official UN colours
     And the SDG badges on theme "SDG Samengesteld" should be "SDG2" and "SDG12" in that order
     And each SDG badge on theme "SDG Samengesteld" should carry its own colour, tooltip and goal link
 
-  # The stored code is free to repeat a goal - the backend pattern SDG<n>(,SDG<n>)*
-  # accepts 'SDG12,SDG12' - and one goal is one badge however often it is named.
-  @ui @theme @sdg @TS-task-022
-  Scenario: AC-5 a repeated SDG code still renders a single badge
-    Given I am recording browser errors
-    When I open the TeacherPage
-    Then the theme "SDG Dubbel" should show exactly 1 SDG badge
-    And the SDG badge for "SDG12" on theme "SDG Dubbel" should be filled with "#BF8B2E"
-    And no browser error should have been recorded
-
   # The "SDG Enkel" line is the positive control: without it every step here also
   # passes for a component that renders nothing at all, whatever it is given.
   @ui @theme @sdg @TS-task-022

--- a/tests/e2e/features/ts-task-022-sdg-badge-component.feature
+++ b/tests/e2e/features/ts-task-022-sdg-badge-component.feature
@@ -49,6 +49,21 @@ Feature: TS-task-022 SDG badge component with official UN colours
     And the SDG badges on theme "SDG Samengesteld" should be "SDG2" and "SDG12" in that order
     And each SDG badge on theme "SDG Samengesteld" should carry its own colour, tooltip and goal link
 
+  # One goal is one badge however often it is named, and that dedupe is what keeps
+  # the goal number usable as a React key. Since TS-task-028 the theme API rejects a
+  # repeated code, so unlike every other scenario here this one cannot stage its
+  # theme through the API - but the seeds write sdgCode as raw TypeQL and the schema
+  # holds no uniqueness constraint, so the database can still hand the component
+  # this. Hence the stub: it is the state a healthy backend will no longer serve.
+  @ui @theme @sdg @TS-task-022
+  Scenario: AC-5 a repeated SDG code still renders a single badge
+    Given the themes endpoint returns a theme whose SDG code repeats a goal
+    And I am recording browser errors
+    When I open the TeacherPage
+    Then the theme "SDG Dubbel" should show exactly 1 SDG badge
+    And the SDG badge for "SDG12" on theme "SDG Dubbel" should be filled with "#BF8B2E"
+    And no browser error should have been recorded
+
   # The "SDG Enkel" line is the positive control: without it every step here also
   # passes for a component that renders nothing at all, whatever it is given.
   @ui @theme @sdg @TS-task-022

--- a/tests/e2e/features/ts-task-028-duplicate-sdg-codes.feature
+++ b/tests/e2e/features/ts-task-028-duplicate-sdg-codes.feature
@@ -1,0 +1,88 @@
+Feature: TS-task-028 duplicate SDG codes are rejected on theme CRUD
+
+  As a teacher
+  I want the platform to reject a theme whose SDG list names the same goal twice
+  So that a theme's SDG links stay a set and a stored code means exactly one thing
+
+  # TS-task-004 (#287) introduced the SDG-code format pattern
+  # SDG<n>(,SDG<n>)*, which accepts a repeated goal: "SDG12,SDG12" was created
+  # with 201 before this task. "No repeated group" is not expressible in that
+  # regex without enumerating every pair, so format and uniqueness are two
+  # separate rules with two separate messages - which is what the precedence
+  # scenario below pins down.
+  #
+  # Every step here already exists for the TS-task-004 suite
+  # (theme-input-validation.feature); this feature adds scenarios, not step code.
+
+  # AC-1 (create) and AC-2 (update). Both an adjacent repeat and a repeat
+  # separated by another goal are covered on both verbs on purpose: a
+  # regex-shaped fix would plausibly catch "SDG12,SDG12" while letting
+  # "SDG2,SDG12,SDG2" through, and validate_theme() is shared by both routes.
+  # On update, the persistence step re-reads every field, so AC-2's "the stored
+  # theme is unchanged" is genuinely verified rather than assumed from the 400.
+  @api @theme @TS-task-028
+  Scenario Outline: A repeated SDG code is rejected and nothing is stored
+    Given I am authenticated as the E2E teacher
+    When I submit a theme "<operation>" request with validation field "sdg_code" set to "<value>"
+    Then the latest theme API response status should be 400
+    And the latest API error detail should equal "SDG-codes mogen niet dubbel voorkomen"
+    And no invalid theme data should be persisted from the latest validation request
+
+    Examples: repeat adjacent, separated, and repeated three times
+      | operation | value            |
+      | create    | SDG12,SDG12      |
+      | create    | SDG3,SDG7,SDG3   |
+      | create    | SDG1,SDG1,SDG1   |
+      | update    | SDG2,SDG12,SDG2  |
+      | update    | SDG5,SDG5        |
+      | update    | SDG17,SDG4,SDG17 |
+
+  # AC-3, and the negative control for the rule above: rejecting a repeat must
+  # not turn into rejecting every compound code. Without this, an implementation
+  # that refused all commas would satisfy every rejection scenario here.
+  @api @theme @TS-task-028
+  Scenario Outline: Distinct SDG codes are still accepted and stored
+    Given I am authenticated as the E2E teacher
+    When I create a theme with validation field "sdg_code" set to "<value>"
+    Then the latest theme API response status should be 201
+    And the persisted latest theme field "sdg_code" should equal "<value>"
+
+    Examples: a single code and a distinct compound code
+      | value      |
+      | SDG9       |
+      | SDG2,SDG12 |
+
+  # AC-5. The malformed-AND-repeated values are the interesting half: they
+  # satisfy neither rule, so they prove the format check still runs first and
+  # the new duplicate message does not swallow the format message. The three
+  # plain malformed values keep AC-5's own examples traceable to this task.
+  @api @theme @TS-task-028
+  Scenario Outline: Malformed SDG codes keep the existing format message
+    Given I am authenticated as the E2E teacher
+    When I submit a theme "<operation>" request with validation field "sdg_code" set to "<value>"
+    Then the latest theme API response status should be 400
+    And the latest API error detail should equal "Ongeldig SDG-code formaat. Gebruik bijv. 'SDG1' of 'SDG12,SDG4'"
+    And no invalid theme data should be persisted from the latest validation request
+
+    Examples: malformed only
+      | operation | value  |
+      | create    | BANANA |
+      | create    | SDG0   |
+      | create    | SDG18  |
+
+    Examples: malformed and repeated - format is reported, not duplication
+      | operation | value         |
+      | create    | BANANA,BANANA |
+      | create    | SDG18,SDG18   |
+      | create    | SDG0,SDG0     |
+      | update    | SDG18,SDG18   |
+
+  # Guards the falsy branch the uniqueness check must not reach: an empty
+  # sdg_code clears the field (theme_repository.update deletes the attribute) and
+  # must not be read as a one-element list, or as a duplicate of anything.
+  @api @theme @TS-task-028
+  Scenario: An empty SDG code still clears the field
+    Given I am authenticated as the E2E teacher
+    When I update a theme with validation field "sdg_code" set to "empty"
+    Then the latest theme API response status should be 200
+    And the persisted latest theme field "sdg_code" should equal "null"

--- a/tests/e2e/features/ts-task-028-duplicate-sdg-codes.feature
+++ b/tests/e2e/features/ts-task-028-duplicate-sdg-codes.feature
@@ -29,13 +29,12 @@ Feature: TS-task-028 duplicate SDG codes are rejected on theme CRUD
     And no invalid theme data should be persisted from the latest validation request
 
     Examples: repeat adjacent, separated, and repeated three times
-      | operation | value            |
-      | create    | SDG12,SDG12      |
-      | create    | SDG3,SDG7,SDG3   |
-      | create    | SDG1,SDG1,SDG1   |
-      | update    | SDG2,SDG12,SDG2  |
-      | update    | SDG5,SDG5        |
-      | update    | SDG17,SDG4,SDG17 |
+      | operation | value           |
+      | create    | SDG12,SDG12     |
+      | create    | SDG3,SDG7,SDG3  |
+      | create    | SDG1,SDG1,SDG1  |
+      | update    | SDG2,SDG12,SDG2 |
+      | update    | SDG5,SDG5       |
 
   # AC-3, and the negative control for the rule above: rejecting a repeat must
   # not turn into rejecting every compound code. Without this, an implementation
@@ -52,10 +51,12 @@ Feature: TS-task-028 duplicate SDG codes are rejected on theme CRUD
       | SDG9       |
       | SDG2,SDG12 |
 
-  # AC-5. The malformed-AND-repeated values are the interesting half: they
-  # satisfy neither rule, so they prove the format check still runs first and
-  # the new duplicate message does not swallow the format message. The three
-  # plain malformed values keep AC-5's own examples traceable to this task.
+  # AC-5. Plain malformed values are already covered by TS-task-004
+  # (theme-input-validation.feature), so this only carries what that suite cannot:
+  # values that are malformed AND repeated. They satisfy neither rule, so they
+  # prove the format check still runs first and the new duplicate message does not
+  # swallow the format message. Both malformed shapes are covered - a token that is
+  # not SDG-like at all, and one that is SDG-like but out of range.
   @api @theme @TS-task-028
   Scenario Outline: Malformed SDG codes keep the existing format message
     Given I am authenticated as the E2E teacher
@@ -64,22 +65,17 @@ Feature: TS-task-028 duplicate SDG codes are rejected on theme CRUD
     And the latest API error detail should equal "Ongeldig SDG-code formaat. Gebruik bijv. 'SDG1' of 'SDG12,SDG4'"
     And no invalid theme data should be persisted from the latest validation request
 
-    Examples: malformed only
-      | operation | value  |
-      | create    | BANANA |
-      | create    | SDG0   |
-      | create    | SDG18  |
-
     Examples: malformed and repeated - format is reported, not duplication
       | operation | value         |
       | create    | BANANA,BANANA |
       | create    | SDG18,SDG18   |
-      | create    | SDG0,SDG0     |
       | update    | SDG18,SDG18   |
 
-  # Guards the falsy branch the uniqueness check must not reach: an empty
-  # sdg_code clears the field (theme_repository.update deletes the attribute) and
-  # must not be read as a one-element list, or as a duplicate of anything.
+  # An empty sdg_code clears the field (theme_repository.update deletes the
+  # attribute) and must keep doing so. This guards the falsy guard itself: tighten
+  # `and theme.sdg_code:` to `is not None` - a plausible move when adding a second
+  # rule under it - and "" starts failing the format check with a 400 instead of
+  # clearing. TS-task-004 covers a null sdg_code on update, but never "".
   @api @theme @TS-task-028
   Scenario: An empty SDG code still clears the field
     Given I am authenticated as the E2E teacher

--- a/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
+++ b/tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs
@@ -13,6 +13,7 @@ const { Given, When, Then } = require('@qavajs/core');
 const { E2E_TEACHER_ID } = require('../support/test-data.cjs');
 const { page, authenticateInBrowser } = require('../support/e2e-session.cjs');
 const { resetThemeCatalog } = require('../support/theme-catalog.cjs');
+const { stubThemesEndpoint } = require('../support/theme-stub.cjs');
 const { hexToRgb, parseCssColor, contrastRatio, MINIMUM_CONTRAST_RATIO } = require('../support/theme-color.cjs');
 const {
   TS022_THEME_PAYLOADS,
@@ -118,6 +119,28 @@ Given('I am authenticated in the browser as the TS-task-022 teacher', async func
 
 Given('the theme catalog contains only the TS-022 SDG fixtures', async function () {
   await resetThemeCatalog(TS022_THEME_PAYLOADS);
+});
+
+// The one badge state the real backend will no longer serve: TS-task-028 rejects a
+// repeated goal on POST/PUT /themes/, so this cannot be staged through the API the
+// way the other fixtures are. It is still data the component can be handed - the
+// seeds write sdgCode as raw TypeQL and schema.tql puts no uniqueness constraint on
+// it - which is exactly what theme-stub.cjs reserves stubbing for. A stable id is
+// included because the row keys on it.
+const REPEATED_SDG_STUB_CATALOG = Object.freeze([
+  Object.freeze({
+    id: 'ts022-stub-repeated-sdg',
+    name: 'SDG Dubbel',
+    sdg_code: 'SDG12,SDG12',
+    icon: 'content_copy',
+    color: '#795548',
+    display_order: 1,
+    description: 'Dezelfde SDG-code twee keer.',
+  }),
+]);
+
+Given('the themes endpoint returns a theme whose SDG code repeats a goal', async function () {
+  await stubThemesEndpoint(page(this), { status: 200, body: REPEATED_SDG_STUB_CATALOG });
 });
 
 // Deliberately a step rather than a hook: the Background's authentication already

--- a/tests/e2e/support/sdg-catalog.cjs
+++ b/tests/e2e/support/sdg-catalog.cjs
@@ -82,15 +82,11 @@ const expectedGoalUrl = (code) => `https://sdgs.un.org/goals/goal${sdgNumber(cod
 //   SDG Licht         light fill (SDG7)      AC-7
 //   SDG Alle          all 17 codes at once   AC-2, AC-7 (contrast sweep)
 //   SDG Geen          no sdg_code at all     AC-6
-//   SDG Dubbel        the same code twice    AC-5 (repeat)
 //
 // "SDG Enkel" carries display_order 1 so it renders in the first theme row: the
 // keyboard-focus scenario tabs to it from the top of the page, and a first row
 // keeps that walk short. Omitting sdg_code entirely on "SDG Geen" is what sends
 // a null sdgCode into the component, which is exactly what AC-6 is about.
-//
-// "SDG Dubbel" is not a typo: the backend's code pattern is SDG<n>(,SDG<n>)*,
-// which accepts a repeat, so 'SDG12,SDG12' is data the badge can really be handed.
 const TS022_THEME_FIXTURES = Object.freeze([
   Object.freeze({ name: 'SDG Enkel', sdg_code: 'SDG12', icon: 'eco', color: '#4CAF50', display_order: 1, description: 'Eén SDG-code.' }),
   Object.freeze({ name: 'SDG Samengesteld', sdg_code: 'SDG2,SDG12', icon: 'restaurant', color: '#FF9800', display_order: 2, description: 'Twee SDG-codes.' }),
@@ -98,7 +94,6 @@ const TS022_THEME_FIXTURES = Object.freeze([
   Object.freeze({ name: 'SDG Licht', sdg_code: 'SDG7', icon: 'bolt', color: '#FFC107', display_order: 4, description: 'Lichte SDG-kleur.' }),
   Object.freeze({ name: 'SDG Alle', sdg_code: ALL_SDG_CODES.join(','), icon: 'public', color: '#2196F3', display_order: 5, description: 'Alle zeventien SDG-codes.' }),
   Object.freeze({ name: 'SDG Geen', sdg_code: null, icon: 'category', color: '#9E9E9E', display_order: 6, description: 'Geen SDG-code.' }),
-  Object.freeze({ name: 'SDG Dubbel', sdg_code: 'SDG12,SDG12', icon: 'content_copy', color: '#795548', display_order: 7, description: 'Dezelfde SDG-code twee keer.' }),
 ]);
 
 /** The fixture themes as the theme API accepts them: a null sdg_code is omitted, not sent. */
@@ -106,16 +101,11 @@ const TS022_THEME_PAYLOADS = Object.freeze(
   TS022_THEME_FIXTURES.map(({ sdg_code: sdgCode, ...rest }) => Object.freeze(sdgCode ? { ...rest, sdg_code: sdgCode } : rest)),
 );
 
-/**
- * The codes a fixture theme must render badges for, in order; [] when it has none.
- *
- * Distinct codes, because a badge stands for a goal: naming SDG12 twice is still
- * one goal, so "SDG Dubbel" expects one badge and not two.
- */
+/** The codes a fixture theme must render badges for, in order; [] when it has none. */
 function expectedCodesFor(themeName) {
   const fixture = TS022_THEME_FIXTURES.find((theme) => theme.name === themeName);
   assert.ok(fixture, `Expected a TS-task-022 fixture theme named '${themeName}'`);
-  return fixture.sdg_code ? [...new Set(fixture.sdg_code.split(','))] : [];
+  return fixture.sdg_code ? fixture.sdg_code.split(',') : [];
 }
 
 // Only what the steps actually consume. The colour/name tables and the fixture


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR rejects duplicate SDG codes during theme creation and updates while retaining defensive frontend deduplication for values introduced outside the API.
- Adds a dedicated duplicate-code validation error and write-time uniqueness check.
- Adds API scenarios for duplicate rejection, valid compound values, format precedence, and clearing the field.
- Stubs the legacy duplicate state in the badge UI scenario because the API no longer accepts it.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| projojo_backend/service/validation_service.py | Adds a separate duplicate-SDG validation check after the existing format check. |
| projojo_frontend/src/utils/sdg.js | Retains ordered deduplication and updates its explanation for raw TypeQL inputs. |
| tests/e2e/features/ts-task-028-duplicate-sdg-codes.feature | Covers duplicate rejection, valid values, error precedence, persistence behavior, and empty-field clearing. |
| tests/e2e/steps/ts-task-022-sdg-badge-component.steps.cjs | Stubs a repeated SDG response so the badge component's defensive behavior remains covered. |

</details>

<sub>Reviews (2): Last reviewed commit: ["AI-review ts-28"](https://github.com/han-aim-cmd-wg/projojo/commit/600bfb1a93aba1850cf99765903885f973448083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57122303)</sub>

**Context used:**

- Context used - AGENTS.md is the coding guide for this repo. It ex... ([source](https://github.com/han-aim-cmd-wg/projojo/blob/main/AGENTS.md))
- Context used - AGENTS.md ([source](https://github.com/han-aim-cmd-wg/projojo/blob/main/AGENTS.md))

<!-- /greptile_comment -->