### PR TITLE
Next UI ts-24 including initDatabase build_query change

### DIFF
--- a/projojo_backend/db/initDatabase.py
+++ b/projojo_backend/db/initDatabase.py
@@ -390,8 +390,13 @@ def build_query(template: str, params: dict[str, Any], allow_none: bool = False)
     # Then substitute regular params
     for key, value in regular_params.items():
         formatted_value = format_value(value)
-        # Use word boundary to avoid partial replacements (e.g., ~id vs ~id_name)
-        result = re.sub(rf'~{re.escape(key)}(?![a-zA-Z0-9_])', formatted_value, result)
+        # Use word boundary to avoid partial replacements (e.g., ~id vs ~id_name).
+        # The replacement MUST be a callback: re.sub reinterprets backslash escapes
+        # in a plain replacement string, which silently undid sanitize_string's
+        # backslash doubling. A value of `a\b` was emitted as "a\b" (TypeQL then
+        # decodes \b as a backspace, i.e. the wrong value) and `a\` produced an
+        # unterminated TypeQL literal. A callback's return value is inserted as-is.
+        result = re.sub(rf'~{re.escape(key)}(?![a-zA-Z0-9_])', lambda _: formatted_value, result)
 
     return result
 

--- a/projojo_backend/db/schema.tql
+++ b/projojo_backend/db/schema.tql
@@ -20,7 +20,8 @@ entity student sub user,
     owns isPortfolioWorldPublic @card(0..1),
     plays hasSkill:student @card(0..),
     plays registersForTask:student @card(0..),
-    plays hasPortfolio:student @card(0..);
+    plays hasPortfolio:student @card(0..),
+    plays hasInterest:student @card(0..);
 
 entity teacher sub user,
     plays portfolioReviewAuthor:author @card(0..);
@@ -70,6 +71,7 @@ entity theme,
     owns themeDescription @card(0..1),
     owns color @card(0..1),         # Kleurcode (bijv. "#4CAF50")
     owns displayOrder @card(0..1),  # Sorteervolgorde
+    plays hasInterest:theme @card(0..),
     plays hasTheme:theme @card(0..);
 
 entity task,
@@ -214,6 +216,11 @@ relation portfolioReviewAuthor,
 # Project-Thema koppeling
 relation hasTheme,
     relates project @card(1),
+    relates theme @card(1);
+
+# Student-Thema interesse: welke thema's een student interessant vindt
+relation hasInterest,
+    relates student @card(1),
     relates theme @card(1);
 
 

--- a/projojo_backend/db/schema.tql
+++ b/projojo_backend/db/schema.tql
@@ -71,8 +71,8 @@ entity theme,
     owns themeDescription @card(0..1),
     owns color @card(0..1),         # Kleurcode (bijv. "#4CAF50")
     owns displayOrder @card(0..1),  # Sorteervolgorde
-    plays hasInterest:theme @card(0..),
-    plays hasTheme:theme @card(0..);
+    plays hasTheme:theme @card(0..),
+    plays hasInterest:theme @card(0..);
 
 entity task,
     owns id @key,

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -405,6 +405,9 @@ class ThemeRepository(BaseRepository[Theme]):
         ]
 
         def validate(results: list[list]) -> None:
+            # Unreachable through the API: @auth(role="student", owner_id_key="student_id")
+            # only admits a student whose own id came from a valid JWT. Kept as a
+            # backstop for a token that outlives its account.
             if not results[0]:
                 raise ValueError(f"Student met ID '{student_id}' niet gevonden.")
             invalid = [theme_id for theme_id, rows in zip(theme_ids, results[2:]) if not rows]

--- a/projojo_backend/domain/repositories/theme_repository.py
+++ b/projojo_backend/domain/repositories/theme_repository.py
@@ -265,6 +265,16 @@ class ThemeRepository(BaseRepository[Theme]):
             delete
                 $hasTheme;
         """
+        # hasInterest requires a theme player (@card(1)), so a student's saved
+        # interest must go with the theme; a removed theme simply disappears
+        # from every student's interests (TS-task-024).
+        delete_interests = """
+            match
+                $theme isa theme, has id ~theme_id;
+                $hasInterest isa hasInterest(theme: $theme);
+            delete
+                $hasInterest;
+        """
         delete_theme = """
             match
                 $theme isa theme, has id ~theme_id;
@@ -273,6 +283,7 @@ class ThemeRepository(BaseRepository[Theme]):
         """
         Db.write_transact_many([
             (delete_relations, {"theme_id": theme_id}),
+            (delete_interests, {"theme_id": theme_id}),
             (delete_theme, {"theme_id": theme_id}),
         ])
 
@@ -337,3 +348,68 @@ class ThemeRepository(BaseRepository[Theme]):
 
         Db.write_transact_atomic([project_query, delete_query, *insert_queries], validate=validate)
         return len(theme_ids)
+
+    def get_student_interests(self, student_id: str) -> list[Theme]:
+        query = """
+            match
+                $student isa student, has id ~student_id;
+                $hasInterest isa hasInterest(student: $student, theme: $theme);
+                $theme has id $id, has name $name;
+            fetch {
+                'id': $id,
+                'name': $name,
+                'sdg_code': [$theme.sdgCode],
+                'icon': [$theme.icon],
+                'description': [$theme.themeDescription],
+                'color': [$theme.color],
+                'display_order': [$theme.displayOrder]
+            };
+        """
+        # No project counts here, for the same reason as get_themes_by_project:
+        # nothing renders them for a student's own interests.
+        results = Db.read_transact(query, {"student_id": student_id})
+        return [self._map_to_model(result) for result in results]
+
+    def update_student_interests(self, student_id: str, theme_ids: list[str]) -> list[Theme]:
+        """Atomically replace a student's theme interests: all changes succeed or none are applied.
+
+        Duplicate theme ids are ignored. Returns the interests as stored afterwards.
+
+        Same shape as link_project_to_themes: probe the owner, drop the old links
+        and insert the new ones inside one transaction, and let validate() reject
+        before commit so a bad theme id leaves the previous selection intact.
+        """
+        theme_ids = list(dict.fromkeys(theme_ids))
+        student_query = build_query("""
+            match
+                $student isa student, has id ~student_id;
+        """, {"student_id": student_id})
+        delete_query = build_query("""
+            match
+                $student isa student, has id ~student_id;
+                $hasInterest isa hasInterest(student: $student);
+            delete
+                $hasInterest;
+        """, {"student_id": student_id})
+        insert_template = """
+            match
+                $student isa student, has id ~student_id;
+                $theme isa theme, has id ~theme_id;
+            insert
+                $hasInterest isa hasInterest($student, $theme);
+        """
+
+        insert_queries = [
+            build_query(insert_template, {"student_id": student_id, "theme_id": theme_id})
+            for theme_id in theme_ids
+        ]
+
+        def validate(results: list[list]) -> None:
+            if not results[0]:
+                raise ValueError(f"Student met ID '{student_id}' niet gevonden.")
+            invalid = [theme_id for theme_id, rows in zip(theme_ids, results[2:]) if not rows]
+            if invalid:
+                raise ValueError(f"Thema's niet gevonden: {', '.join(invalid)}")
+
+        Db.write_transact_atomic([student_query, delete_query, *insert_queries], validate=validate)
+        return self.get_student_interests(student_id)

--- a/projojo_backend/routes/student_router.py
+++ b/projojo_backend/routes/student_router.py
@@ -1,12 +1,13 @@
 from fastapi import APIRouter, Path, Body, HTTPException, Request, UploadFile, File, Form
 from auth.permissions import auth
 
-from domain.repositories import SkillRepository, UserRepository
+from domain.repositories import SkillRepository, UserRepository, ThemeRepository
 from domain.models.skill import StudentSkill
 from service.image_service import save_image, delete_image
 
 skill_repo = SkillRepository()
 user_repo = UserRepository()
+theme_repo = ThemeRepository()
 
 router = APIRouter(prefix="/students", tags=["Student Endpoints"])
 
@@ -79,6 +80,38 @@ async def update_student_skill_description(
             status_code=500,
             detail="Er is iets misgegaan bij het opslaan van de beschrijving",
         )
+
+
+@router.get("/{student_id}/interests")
+@auth(role="authenticated")
+async def get_student_interests(student_id: str = Path(..., description="Student ID")):
+    """
+    Get the themes a student is interested in.
+
+    Reading interests is open to every authenticated user (TS-task-024 AC-8).
+    """
+    if not user_repo.get_student_by_id(student_id):
+        raise HTTPException(status_code=404, detail="Student niet gevonden")
+
+    return theme_repo.get_student_interests(student_id)
+
+
+@router.put("/{student_id}/interests")
+@auth(role="student", owner_id_key="student_id")
+async def update_student_interests(
+    student_id: str = Path(..., description="Student ID"),
+    theme_ids: list[str] = Body(..., embed=True),
+):
+    """
+    Replace a student's theme interests with `theme_ids`.
+
+    Only the student themselves may write their own interests, and the number of
+    interests is not capped here (the soft limit of 5 is UI-only).
+    """
+    try:
+        return theme_repo.update_student_interests(student_id, theme_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get("/registrations")

--- a/projojo_backend/tests/test_initDatabase.py
+++ b/projojo_backend/tests/test_initDatabase.py
@@ -136,6 +136,30 @@ class TestBuildQueryReadMode:
             build_query(template, {'id': None}, allow_none=False)
 
 
+class TestBuildQueryEscaping:
+    """build_query must emit sanitize_string's escaping unchanged.
+
+    re.sub reinterprets backslash escapes in a plain replacement string, so a
+    naive substitution undoes the doubling and produces the wrong value or
+    unparseable TypeQL.
+    """
+
+    def test_interior_backslash_stays_doubled(self):
+        template = 'match $x isa theme, has id ~id;'
+        result = build_query(template, {'id': 'a\\b'}, allow_none=False)
+        assert result == 'match $x isa theme, has id "a\\\\b";'
+
+    def test_trailing_backslash_does_not_break_the_literal(self):
+        template = 'match $x isa theme, has id ~id;'
+        result = build_query(template, {'id': 'end\\'}, allow_none=False)
+        assert result == 'match $x isa theme, has id "end\\\\";'
+
+    def test_quote_stays_escaped(self):
+        template = 'match $x isa theme, has name ~name;'
+        result = build_query(template, {'name': 'say "hi"'}, allow_none=False)
+        assert result == 'match $x isa theme, has name "say \\"hi\\"";'
+
+
 class TestBuildQueryWriteMode:
     """Tests for build_query with allow_none=True (write transactions)"""
 

--- a/tests/e2e/features/ts-task-024-student-interest-api.feature
+++ b/tests/e2e/features/ts-task-024-student-interest-api.feature
@@ -1,0 +1,181 @@
+Feature: TS-task-024 student interest schema and backend endpoints
+
+  A student records which themes they are interested in, so the platform can later
+  recommend matching projects. Interests are stored as their own relation and are
+  managed through GET/PUT /students/{student_id}/interests.
+
+  Rule: The schema models a student's interests as a hasInterest relation (AC-1)
+
+    @api @theme @schema @ts-task-024
+    Scenario: The declared schema relates exactly one student to exactly one theme per interest
+      When I inspect the TypeDB schema for student theme interests
+      Then the schema should declare a "hasInterest" relation relating "student" and "theme" with cardinality one
+      And the schema should let the "student" entity play "hasInterest:student" any number of times
+      And the schema should let the "theme" entity play "hasInterest:theme" any number of times
+
+    @api @theme @schema @ts-task-024
+    Scenario: The applied database stores saved interests as hasInterest relations
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid"
+      When I probe the live database for the E2E interest student's hasInterest relations
+      Then the probe should report interest themes "Duurzaamheid"
+
+  Rule: Any authenticated user can read a student's interests (AC-2, AC-3, AC-8)
+
+    @api @theme @ts-task-024
+    Scenario: Saved interests are returned with their theme details
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E interest student
+      When I request the interests of the E2E interest student
+      Then the latest interest API response status should be 200
+      And the latest interest API response should list themes "Duurzaamheid,Klimaat & Milieu"
+      And every listed interest should match the theme catalog on id, name, icon, color and sdg_code
+
+    @api @theme @ts-task-024
+    Scenario: A student without interests gets an empty list
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And the E2E interest student has no interests
+      And I call the interest API as the E2E interest student
+      When I request the interests of the E2E interest student
+      Then the latest interest API response status should be 200
+      And the latest interest API response should be an empty list
+
+    @api @theme @ts-task-024
+    Scenario Outline: Reading interests is open to every authenticated role
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And the E2E interest student has interests "Duurzaamheid"
+      And I call the interest API as the E2E <role>
+      When I request the interests of the E2E interest student
+      Then the latest interest API response status should be 200
+      And the latest interest API response should list themes "Duurzaamheid"
+
+      Examples:
+        | role          |
+        | teacher       |
+        | supervisor    |
+        | other student |
+
+    @api @theme @ts-task-024
+    Scenario: Reading interests without a token is rejected
+      Given I call the interest API without a JWT token
+      When I request the interests of the E2E interest student
+      Then the latest interest API response status should be 401
+
+    @api @theme @ts-task-024
+    Scenario: Reading the interests of an unknown student reports not found
+      Given I call the interest API as the E2E interest student
+      When I request the interests of student "ts-task-024-unknown-student"
+      Then the latest interest API response status should be 404
+      And the latest interest API error detail should equal "Student niet gevonden"
+
+  Rule: A student replaces their whole interest selection in one call (AC-4, AC-5, AC-10)
+
+    @api @theme @ts-task-024
+    Scenario: Saving a new selection replaces the previous one
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie,Water & Biodiversiteit"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with themes "Innovatie & Technologie,Water & Biodiversiteit"
+      Then the latest interest API response status should be 200
+      And the latest interest API response should list themes "Innovatie & Technologie,Water & Biodiversiteit"
+      And the persisted interests of the E2E interest student should be exactly "Innovatie & Technologie,Water & Biodiversiteit"
+
+    @api @theme @ts-task-024
+    Scenario: Saving an empty selection clears every interest
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with no themes
+      Then the latest interest API response status should be 200
+      And the latest interest API response should be an empty list
+      And the persisted interests of the E2E interest student should be empty
+
+    @api @theme @ts-task-024
+    Scenario: A selection of seven themes is saved in full
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie,Water & Biodiversiteit,Voedselzekerheid,Kennisdeling,Onderwijs"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with themes "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie,Water & Biodiversiteit,Voedselzekerheid,Kennisdeling,Onderwijs"
+      Then the latest interest API response status should be 200
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie,Water & Biodiversiteit,Voedselzekerheid,Kennisdeling,Onderwijs"
+
+    @api @theme @ts-task-024
+    Scenario: A theme sent twice is saved once
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with theme "Duurzaamheid" sent twice
+      Then the latest interest API response status should be 200
+      And the persisted interests of the E2E interest student should contain "Duurzaamheid" exactly once
+
+    @api @theme @ts-task-024
+    Scenario: A non-list theme_ids value is rejected as unprocessable
+      Given I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with a non-list theme_ids value
+      Then the latest interest API response status should be 422
+
+  Rule: Unknown theme ids are rejected without changing anything (AC-6, AC-9)
+
+    @api @theme @integrity @ts-task-024
+    Scenario: An unknown theme id is reported and the saved selection is kept
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with themes "Innovatie & Technologie" and invalid theme ids "ts-task-024-missing-theme"
+      Then the latest interest API response status should be 400
+      And the latest interest API error detail should contain "ts-task-024-missing-theme"
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid,Klimaat & Milieu"
+      And the persisted interests of the E2E interest student should not contain "Innovatie & Technologie"
+
+    @api @theme @integrity @ts-task-024
+    Scenario: Every unknown theme id is listed in the error
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And the E2E interest student has interests "Duurzaamheid"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with invalid theme ids "ts-task-024-missing-a,ts-task-024-missing-b"
+      Then the latest interest API response status should be 400
+      And the latest interest API error detail should contain "ts-task-024-missing-a"
+      And the latest interest API error detail should contain "ts-task-024-missing-b"
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"
+
+  Rule: Only the student themselves may change their interests (AC-7)
+
+    @api @theme @security @ts-task-024
+    Scenario Outline: Other users cannot change a student's interests
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid"
+      And I call the interest API as the E2E <role>
+      When I replace the E2E interest student's interests with themes "Klimaat & Milieu"
+      Then the latest interest API response status should be 403
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"
+
+      Examples:
+        | role          |
+        | other student |
+        | supervisor    |
+        | teacher       |
+
+    @api @theme @security @ts-task-024
+    Scenario: Changing interests without a token is rejected
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid"
+      And I call the interest API without a JWT token
+      When I replace the E2E interest student's interests with themes "Klimaat & Milieu"
+      Then the latest interest API response status should be 401
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"
+
+    @api @theme @security @ts-task-024
+    Scenario: A student cannot write interests under an unknown student id
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And I call the interest API as the E2E interest student
+      When I replace the interests of student "ts-task-024-unknown-student" with themes "Duurzaamheid"
+      Then the latest interest API response status should be 403
+
+  Rule: Removing a theme keeps saved interests consistent
+
+    @api @theme @integrity @ts-task-024
+    Scenario: Deleting a theme removes it from the students who saved it
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      When the E2E teacher deletes theme "Klimaat & Milieu"
+      Then the theme deletion should have succeeded
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"

--- a/tests/e2e/features/ts-task-024-student-interest-api.feature
+++ b/tests/e2e/features/ts-task-024-student-interest-api.feature
@@ -20,6 +20,16 @@ Feature: TS-task-024 student interest schema and backend endpoints
       When I probe the live database for the E2E interest student's hasInterest relations
       Then the probe should report interest themes "Duurzaamheid"
 
+    @api @theme @schema @ts-task-024
+    Scenario: Two students can save the same theme as an interest
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E other student
+      When I replace the E2E other student's interests with themes "Duurzaamheid"
+      Then the latest interest API response status should be 200
+      And the persisted interests of the E2E other student should be exactly "Duurzaamheid"
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid,Klimaat & Milieu"
+
   Rule: Any authenticated user can read a student's interests (AC-2, AC-3, AC-8)
 
     @api @theme @ts-task-024
@@ -100,6 +110,17 @@ Feature: TS-task-024 student interest schema and backend endpoints
       And the persisted interests of the E2E interest student should be exactly "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie,Water & Biodiversiteit,Voedselzekerheid,Kennisdeling,Onderwijs"
 
     @api @theme @ts-task-024
+    Scenario: A selection that overlaps the previous one keeps the shared theme once
+      Given the E2E theme catalog contains themes "Duurzaamheid,Klimaat & Milieu,Innovatie & Technologie"
+      And the E2E interest student has interests "Duurzaamheid,Klimaat & Milieu"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with themes "Klimaat & Milieu,Innovatie & Technologie"
+      Then the latest interest API response status should be 200
+      And the persisted interests of the E2E interest student should be exactly "Klimaat & Milieu,Innovatie & Technologie"
+      And the persisted interests of the E2E interest student should contain "Klimaat & Milieu" exactly once
+      And the persisted interests of the E2E interest student should not contain "Duurzaamheid"
+
+    @api @theme @ts-task-024
     Scenario: A theme sent twice is saved once
       Given the E2E theme catalog contains themes "Duurzaamheid"
       And I call the interest API as the E2E interest student
@@ -135,6 +156,16 @@ Feature: TS-task-024 student interest schema and backend endpoints
       Then the latest interest API response status should be 400
       And the latest interest API error detail should contain "ts-task-024-missing-a"
       And the latest interest API error detail should contain "ts-task-024-missing-b"
+      And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"
+
+    @api @theme @integrity @ts-task-024
+    Scenario: A theme id ending in a backslash is rejected like any other unknown id
+      Given the E2E theme catalog contains themes "Duurzaamheid"
+      And the E2E interest student has interests "Duurzaamheid"
+      And I call the interest API as the E2E interest student
+      When I replace the E2E interest student's interests with a theme id ending in a backslash
+      Then the latest interest API response status should be 400
+      And the latest interest API error detail should list the backslash theme id in full
       And the persisted interests of the E2E interest student should be exactly "Duurzaamheid"
 
   Rule: Only the student themselves may change their interests (AC-7)

--- a/tests/e2e/steps/theme-integrity.steps.cjs
+++ b/tests/e2e/steps/theme-integrity.steps.cjs
@@ -253,7 +253,11 @@ When('I inspect the TypeDB schema for the theme entity', async function () {
 });
 
 Then('the theme name attribute should be required and unique', function () {
-  const themeBlock = themeState(this).inspectedText.match(/entity\s+theme,[\s\S]*?plays\s+hasTheme:theme\s+@card\(0\.\.\);/)?.[0] ?? '';
+  // Match the entity declaration up to its terminating semicolon. Anchoring on a
+  // particular last clause instead would make the theme entity's clause ORDER
+  // load-bearing, and adding any clause would fail here with a message about
+  // `owns name` that is nowhere near the real cause.
+  const themeBlock = themeState(this).inspectedText.match(/entity\s+theme,[\s\S]*?;/)?.[0] ?? '';
 
   assert.match(
     themeBlock,
@@ -305,6 +309,9 @@ Given('theme {string} exists', async function (name) {
   await ensureTheme(this, name);
 });
 
+// Also consumed by ts-task-024-student-interest-api.steps.cjs, which stages its
+// theme fixtures through this step rather than adding a second creation path.
+// Renaming it breaks that suite with an "undefined step" far from the cause.
 Given('the E2E theme catalog contains themes {string}', async function (names) {
   await authenticateAs(this, PROOF_TEACHER_USER_ID, 'teacher');
   for (const name of parseThemeNames(names)) {

--- a/tests/e2e/steps/ts-task-024-student-interest-api.steps.cjs
+++ b/tests/e2e/steps/ts-task-024-student-interest-api.steps.cjs
@@ -1,0 +1,422 @@
+// TS-task-024 - student theme interest schema and backend endpoints.
+//
+// Level: API. Every acceptance criterion of the issue is a schema or HTTP
+// contract, so no browser is involved.
+//
+// Two deliberate choices:
+//   * Theme fixtures are staged through the shared theme-integrity step
+//     "the E2E theme catalog contains themes ..." (the E2E seed holds no themes),
+//     so this suite adds no second theme-creation path.
+//   * Assertions about *persisted* interests always read through a fresh teacher
+//     token instead of the scenario's own token. That keeps "what is stored"
+//     verifiable in the scenarios where the caller is unauthenticated or
+//     forbidden, and AC-8 explicitly allows any authenticated user to read.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+
+const { Before, Given, Then, When } = require('@qavajs/core');
+
+const {
+  BACKEND_URL,
+  E2E_STUDENT_ID,
+  E2E_TEACHER_ID,
+  PROOF_SUPERVISOR_USER_ID,
+  PORTFOLIO_SEED_ALIASES,
+} = require('../support/test-data.cjs');
+const { fetchThemes, teacherApi } = require('../support/theme-catalog.cjs');
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const DOCKER_COMPOSE_ARGS = [
+  'compose',
+  '--env-file',
+  '.env.test',
+  '-p',
+  'projojo-e2e',
+  '-f',
+  'docker-compose.base.yml',
+  '-f',
+  'docker-compose.test.yml',
+];
+
+// The student whose interests this suite reads and writes, plus the other actors
+// AC-7 and AC-8 need. "other student" is a second seeded student account; only
+// its id matters here.
+const INTEREST_STUDENT_ID = E2E_STUDENT_ID;
+const ROLE_ACTORS = Object.freeze({
+  'interest student': Object.freeze({ id: INTEREST_STUDENT_ID, type: 'student' }),
+  'other student': Object.freeze({ id: PORTFOLIO_SEED_ALIASES.actors.privateStudent.id, type: 'student' }),
+  teacher: Object.freeze({ id: E2E_TEACHER_ID, type: 'teacher' }),
+  supervisor: Object.freeze({ id: PROOF_SUPERVISOR_USER_ID, type: 'supervisor' }),
+});
+
+Before(function () {
+  this.tsTask024 = { token: null, status: null, payload: null, schemaText: '', probe: null, themeDeletion: null };
+});
+
+function interestState(world) {
+  assert.ok(world.tsTask024, 'Expected TS-task-024 scenario state to be initialised');
+  return world.tsTask024;
+}
+
+/** Call the backend with an explicit token and return {status, body}. */
+async function backendApi(pathname, token, options = {}) {
+  const response = await fetch(`${BACKEND_URL}${pathname}`, {
+    ...options,
+    headers: {
+      Accept: 'application/json',
+      ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      // Keep raw text so an unexpected non-JSON body fails on the status
+      // assertion with a readable message instead of a JSON.parse crash.
+      body = text;
+    }
+  }
+  return { status: response.status, body };
+}
+
+/** Call the interest API as the scenario's current caller and record the result. */
+async function interestApi(world, pathname, options = {}) {
+  const state = interestState(world);
+  const result = await backendApi(pathname, state.token, options);
+  state.status = result.status;
+  state.payload = result.body;
+  return result;
+}
+
+async function loginAs(role) {
+  const actor = ROLE_ACTORS[role];
+  assert.ok(actor, `Unknown E2E interest actor '${role}'`);
+
+  const response = await fetch(`${BACKEND_URL}/auth/test/login/${actor.id}`, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  });
+  assert.equal(response.status, 200, `Expected test login for the E2E ${role} to return 200, received ${response.status}`);
+
+  const payload = await response.json();
+  assert.equal(payload?.user?.type, actor.type, `Expected the E2E ${role} fixture to be a ${actor.type}, received ${payload?.user?.type}`);
+  assert.ok(payload?.access_token, `Expected test login for the E2E ${role} to return an access token`);
+  return payload.access_token;
+}
+
+function parseNames(names) {
+  return names.split(',').map((name) => name.trim()).filter(Boolean);
+}
+
+/** Resolve theme names to catalog ids, failing loudly on a name that is absent. */
+async function themeIdsForNames(names) {
+  const catalog = await fetchThemes();
+  return parseNames(names).map((name) => {
+    const theme = catalog.find((candidate) => candidate?.name === name);
+    assert.ok(theme?.id, `Expected theme '${name}' in the catalog, found ${JSON.stringify(catalog.map((entry) => entry?.name))}`);
+    return theme.id;
+  });
+}
+
+/**
+ * The interest theme names the backend currently has stored for the interest student.
+ *
+ * Deliberately NOT de-duplicated: the duplicate-id scenario asserts a theme is
+ * returned exactly once, which only means something on the raw response.
+ */
+async function persistedInterestNames() {
+  const result = await teacherApi(`/students/${INTEREST_STUDENT_ID}/interests`);
+  assert.equal(
+    result.status,
+    200,
+    `Expected GET /students/${INTEREST_STUDENT_ID}/interests to return 200, received ${result.status}: ${JSON.stringify(result.body)}`,
+  );
+  assert.ok(Array.isArray(result.body), `Expected stored interests to be a list, received ${JSON.stringify(result.body)}`);
+  return result.body.map((theme) => theme?.name);
+}
+
+/** Save `names` as the interest student's interests through the real endpoint, as that student. */
+async function stageInterests(names) {
+  const token = await loginAs('interest student');
+  const result = await backendApi(`/students/${INTEREST_STUDENT_ID}/interests`, token, {
+    method: 'PUT',
+    body: JSON.stringify({ theme_ids: await themeIdsForNames(names) }),
+  });
+  assert.equal(
+    result.status,
+    200,
+    `Expected interest staging to return 200, received ${result.status}: ${JSON.stringify(result.body)}`,
+  );
+
+  // Staging must not silently under-deliver: read back what the backend stored.
+  assert.deepEqual(
+    [...await persistedInterestNames()].sort(),
+    parseNames(names).sort(),
+    `Expected interest staging to store exactly '${names}'`,
+  );
+}
+
+// --- AC-1: schema ------------------------------------------------------------
+
+When('I inspect the TypeDB schema for student theme interests', async function () {
+  interestState(this).schemaText = await fs.readFile(path.join(REPO_ROOT, 'projojo_backend/db/schema.tql'), 'utf8');
+});
+
+Then(
+  'the schema should declare a {string} relation relating {string} and {string} with cardinality one',
+  function (relationName, firstRole, secondRole) {
+    const relationBlock = interestState(this).schemaText.match(new RegExp(`relation\\s+${relationName}\\s*,[\\s\\S]*?;`))?.[0] ?? '';
+
+    assert.ok(relationBlock, `Expected schema.tql to declare a '${relationName}' relation`);
+    for (const role of [firstRole, secondRole]) {
+      assert.match(
+        relationBlock,
+        new RegExp(`relates\\s+${role}\\s+@card\\(1\\)`),
+        `Expected '${relationName}' to declare \`relates ${role} @card(1)\`, got: ${relationBlock}`,
+      );
+    }
+  },
+);
+
+Then('the schema should let the {string} entity play {string} any number of times', function (entityName, roleReference) {
+  // One `entity <name> ... ;` declaration, up to its terminating semicolon, so a
+  // plays clause from a neighbouring entity cannot satisfy this assertion.
+  const entityBlock = interestState(this).schemaText.match(new RegExp(`entity\\s+${entityName}(?:\\s+sub\\s+\\w+)?\\s*,[\\s\\S]*?;`))?.[0] ?? '';
+
+  assert.ok(entityBlock, `Expected schema.tql to declare the '${entityName}' entity`);
+  assert.match(
+    entityBlock,
+    new RegExp(`plays\\s+${roleReference.replace(':', '\\s*:\\s*')}\\s+@card\\(0\\.\\.\\)`),
+    `Expected '${entityName}' to declare \`plays ${roleReference} @card(0..)\`, got: ${entityBlock}`,
+  );
+});
+
+/**
+ * Read the student's interest links straight out of the running TypeDB, matching
+ * the relation and its roles by name. This is what makes AC-1 an assertion about
+ * the *applied* schema rather than about the schema file.
+ */
+function hasInterestProbeSource(studentId) {
+  return String.raw`
+import json
+
+from db.initDatabase import Db
+
+
+def main() -> None:
+    try:
+        rows = Db.read_transact("""
+match
+  $student isa student, has id "${studentId}";
+  $interest isa hasInterest (student: $student, theme: $theme);
+  $theme has name $name;
+fetch {
+  'name': $name
+};
+""", sort_fields=False)
+        result = {'names': sorted(row['name'] for row in rows)}
+    except Exception as error:
+        result = {'probe_error': str(error)}
+    finally:
+        Db.close()
+
+    print(json.dumps(result))
+
+
+main()
+`;
+}
+
+When("I probe the live database for the E2E interest student's hasInterest relations", async function () {
+  const { stdout, stderr } = await execFileAsync(
+    'docker',
+    [...DOCKER_COMPOSE_ARGS, 'exec', '-T', 'backend', 'uv', 'run', 'python', '-c', hasInterestProbeSource(INTEREST_STUDENT_ID)],
+    { cwd: REPO_ROOT, maxBuffer: 1024 * 1024 * 10 },
+  );
+
+  const jsonLine = stdout.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean).at(-1);
+  assert.ok(jsonLine, `Expected the hasInterest probe to print JSON. stderr: ${stderr}`);
+  interestState(this).probe = JSON.parse(jsonLine);
+});
+
+Then('the probe should report interest themes {string}', function (names) {
+  const probe = interestState(this).probe;
+  assert.ok(probe, 'Expected the hasInterest probe to have run');
+  assert.equal(probe.probe_error, undefined, `Expected the hasInterest probe to succeed, received: ${probe.probe_error}`);
+  assert.deepEqual(probe.names, parseNames(names).sort());
+});
+
+// --- Callers -----------------------------------------------------------------
+
+Given('I call the interest API as the E2E {}', async function (role) {
+  interestState(this).token = await loginAs(role);
+});
+
+Given('I call the interest API without a JWT token', function () {
+  interestState(this).token = null;
+});
+
+// --- Staging -----------------------------------------------------------------
+
+Given('the E2E interest student has interests {string}', async function (names) {
+  await stageInterests(names);
+});
+
+Given('the E2E interest student has no interests', async function () {
+  await stageInterests('');
+});
+
+// --- Requests ----------------------------------------------------------------
+
+When('I request the interests of the E2E interest student', async function () {
+  await interestApi(this, `/students/${INTEREST_STUDENT_ID}/interests`);
+});
+
+When('I request the interests of student {string}', async function (studentId) {
+  await interestApi(this, `/students/${studentId}/interests`);
+});
+
+async function putInterests(world, studentId, themeIds) {
+  await interestApi(world, `/students/${studentId}/interests`, {
+    method: 'PUT',
+    body: JSON.stringify({ theme_ids: themeIds }),
+  });
+}
+
+When("I replace the E2E interest student's interests with themes {string}", async function (names) {
+  await putInterests(this, INTEREST_STUDENT_ID, await themeIdsForNames(names));
+});
+
+When("I replace the E2E interest student's interests with no themes", async function () {
+  await putInterests(this, INTEREST_STUDENT_ID, []);
+});
+
+When("I replace the E2E interest student's interests with theme {string} sent twice", async function (name) {
+  const [themeId] = await themeIdsForNames(name);
+  await putInterests(this, INTEREST_STUDENT_ID, [themeId, themeId]);
+});
+
+When(
+  "I replace the E2E interest student's interests with themes {string} and invalid theme ids {string}",
+  async function (names, invalidThemeIds) {
+    await putInterests(this, INTEREST_STUDENT_ID, [...await themeIdsForNames(names), ...parseNames(invalidThemeIds)]);
+  },
+);
+
+When("I replace the E2E interest student's interests with invalid theme ids {string}", async function (invalidThemeIds) {
+  await putInterests(this, INTEREST_STUDENT_ID, parseNames(invalidThemeIds));
+});
+
+When("I replace the E2E interest student's interests with a non-list theme_ids value", async function () {
+  await interestApi(this, `/students/${INTEREST_STUDENT_ID}/interests`, {
+    method: 'PUT',
+    body: JSON.stringify({ theme_ids: 'Duurzaamheid' }),
+  });
+});
+
+When('I replace the interests of student {string} with themes {string}', async function (studentId, names) {
+  await putInterests(this, studentId, await themeIdsForNames(names));
+});
+
+When('the E2E teacher deletes theme {string}', async function (name) {
+  const [themeId] = await themeIdsForNames(name);
+  interestState(this).themeDeletion = await teacherApi(`/themes/${themeId}`, { method: 'DELETE' });
+});
+
+// --- Response assertions -----------------------------------------------------
+
+Then('the latest interest API response status should be {int}', function (expectedStatus) {
+  const state = interestState(this);
+  assert.equal(
+    state.status,
+    expectedStatus,
+    `Expected the latest interest API status to be ${expectedStatus}, received ${state.status}: ${JSON.stringify(state.payload)}`,
+  );
+});
+
+Then('the latest interest API error detail should equal {string}', function (expectedDetail) {
+  assert.equal(interestState(this).payload?.detail, expectedDetail);
+});
+
+Then('the latest interest API error detail should contain {string}', function (expectedFragment) {
+  const detail = interestState(this).payload?.detail;
+  assert.ok(
+    typeof detail === 'string' && detail.includes(expectedFragment),
+    `Expected the error detail to contain '${expectedFragment}', received ${JSON.stringify(detail)}`,
+  );
+});
+
+Then('the latest interest API response should list themes {string}', function (names) {
+  const payload = interestState(this).payload;
+  assert.ok(Array.isArray(payload), `Expected the latest interest API response to be a list, received ${JSON.stringify(payload)}`);
+  assert.deepEqual(payload.map((theme) => theme?.name).sort(), parseNames(names).sort());
+});
+
+Then('the latest interest API response should be an empty list', function () {
+  assert.deepEqual(interestState(this).payload, []);
+});
+
+Then('every listed interest should match the theme catalog on id, name, icon, color and sdg_code', async function () {
+  const payload = interestState(this).payload;
+  assert.ok(Array.isArray(payload) && payload.length > 0, `Expected a non-empty interest list, received ${JSON.stringify(payload)}`);
+
+  const catalog = await fetchThemes();
+  for (const interest of payload) {
+    const catalogTheme = catalog.find((theme) => theme?.id === interest?.id);
+    assert.ok(catalogTheme, `Expected interest id '${interest?.id}' to exist in the theme catalog`);
+
+    for (const field of ['id', 'name', 'icon', 'color', 'sdg_code']) {
+      // Non-empty first: an interest whose icon/color/sdg_code came back null
+      // would otherwise pass the comparison without proving anything.
+      assert.ok(
+        typeof interest[field] === 'string' && interest[field].length > 0,
+        `Expected interest '${interest?.name}' to expose a non-empty ${field}, received ${JSON.stringify(interest[field])}`,
+      );
+      assert.equal(
+        interest[field],
+        catalogTheme[field],
+        `Expected interest '${interest.name}' field ${field} to match the catalog value ${JSON.stringify(catalogTheme[field])}`,
+      );
+    }
+  }
+});
+
+Then('the theme deletion should have succeeded', function () {
+  const result = interestState(this).themeDeletion;
+  assert.ok(result, 'Expected a theme deletion to have been attempted');
+  assert.equal(
+    result.status,
+    200,
+    `Expected the theme deletion to return 200, received ${result.status}: ${JSON.stringify(result.body)}`,
+  );
+});
+
+// --- Persisted-state assertions ---------------------------------------------
+
+Then('the persisted interests of the E2E interest student should be exactly {string}', async function (names) {
+  assert.deepEqual([...await persistedInterestNames()].sort(), parseNames(names).sort());
+});
+
+Then('the persisted interests of the E2E interest student should be empty', async function () {
+  assert.deepEqual(await persistedInterestNames(), []);
+});
+
+Then('the persisted interests of the E2E interest student should contain {string} exactly once', async function (name) {
+  const storedNames = await persistedInterestNames();
+  const occurrences = storedNames.filter((stored) => stored === name).length;
+  assert.equal(occurrences, 1, `Expected '${name}' to be stored exactly once, found ${occurrences} in ${JSON.stringify(storedNames)}`);
+});
+
+Then('the persisted interests of the E2E interest student should not contain {string}', async function (name) {
+  const storedNames = await persistedInterestNames();
+  assert.ok(!storedNames.includes(name), `Expected '${name}' not to be stored, found ${JSON.stringify(storedNames)}`);
+});

--- a/tests/e2e/steps/ts-task-024-student-interest-api.steps.cjs
+++ b/tests/e2e/steps/ts-task-024-student-interest-api.steps.cjs
@@ -27,7 +27,7 @@ const {
   PROOF_SUPERVISOR_USER_ID,
   PORTFOLIO_SEED_ALIASES,
 } = require('../support/test-data.cjs');
-const { fetchThemes, teacherApi } = require('../support/theme-catalog.cjs');
+const { fetchThemes, teacherApi, themeApi, themeIdsFor } = require('../support/theme-catalog.cjs');
 
 const execFileAsync = promisify(execFile);
 
@@ -48,12 +48,19 @@ const DOCKER_COMPOSE_ARGS = [
 // AC-7 and AC-8 need. "other student" is a second seeded student account; only
 // its id matters here.
 const INTEREST_STUDENT_ID = E2E_STUDENT_ID;
+const OTHER_STUDENT_ID = PORTFOLIO_SEED_ALIASES.actors.privateStudent.id;
 const ROLE_ACTORS = Object.freeze({
   'interest student': Object.freeze({ id: INTEREST_STUDENT_ID, type: 'student' }),
-  'other student': Object.freeze({ id: PORTFOLIO_SEED_ALIASES.actors.privateStudent.id, type: 'student' }),
+  'other student': Object.freeze({ id: OTHER_STUDENT_ID, type: 'student' }),
   teacher: Object.freeze({ id: E2E_TEACHER_ID, type: 'teacher' }),
   supervisor: Object.freeze({ id: PROOF_SUPERVISOR_USER_ID, type: 'supervisor' }),
 });
+
+// A theme id ending in a backslash. This is the input class that made build_query
+// emit unparseable TypeQL (HTTP 500) instead of the clean AC-6 miss, and a single
+// trailing backslash cannot be written inside a Gherkin {string}, so the value
+// lives here and the feature refers to its shape.
+const BACKSLASH_THEME_ID = 'ts-task-024-missing-theme\\';
 
 Before(function () {
   this.tsTask024 = { token: null, status: null, payload: null, schemaText: '', probe: null, themeDeletion: null };
@@ -64,34 +71,10 @@ function interestState(world) {
   return world.tsTask024;
 }
 
-/** Call the backend with an explicit token and return {status, body}. */
-async function backendApi(pathname, token, options = {}) {
-  const response = await fetch(`${BACKEND_URL}${pathname}`, {
-    ...options,
-    headers: {
-      Accept: 'application/json',
-      ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-  const text = await response.text();
-  let body = null;
-  if (text) {
-    try {
-      body = JSON.parse(text);
-    } catch {
-      // Keep raw text so an unexpected non-JSON body fails on the status
-      // assertion with a readable message instead of a JSON.parse crash.
-      body = text;
-    }
-  }
-  return { status: response.status, body };
-}
-
 /** Call the interest API as the scenario's current caller and record the result. */
 async function interestApi(world, pathname, options = {}) {
   const state = interestState(world);
-  const result = await backendApi(pathname, state.token, options);
+  const result = await themeApi(pathname, state.token, options);
   state.status = result.status;
   state.payload = result.body;
   return result;
@@ -117,37 +100,30 @@ function parseNames(names) {
   return names.split(',').map((name) => name.trim()).filter(Boolean);
 }
 
-/** Resolve theme names to catalog ids, failing loudly on a name that is absent. */
-async function themeIdsForNames(names) {
-  const catalog = await fetchThemes();
-  return parseNames(names).map((name) => {
-    const theme = catalog.find((candidate) => candidate?.name === name);
-    assert.ok(theme?.id, `Expected theme '${name}' in the catalog, found ${JSON.stringify(catalog.map((entry) => entry?.name))}`);
-    return theme.id;
-  });
-}
+/** Resolve a comma-separated list of theme names to catalog ids. */
+const themeIdsForNames = (names) => themeIdsFor(parseNames(names));
 
 /**
- * The interest theme names the backend currently has stored for the interest student.
+ * The interest theme names the backend currently has stored for a student.
  *
  * Deliberately NOT de-duplicated: the duplicate-id scenario asserts a theme is
  * returned exactly once, which only means something on the raw response.
  */
-async function persistedInterestNames() {
-  const result = await teacherApi(`/students/${INTEREST_STUDENT_ID}/interests`);
+async function persistedInterestNames(studentId) {
+  const result = await teacherApi(`/students/${studentId}/interests`);
   assert.equal(
     result.status,
     200,
-    `Expected GET /students/${INTEREST_STUDENT_ID}/interests to return 200, received ${result.status}: ${JSON.stringify(result.body)}`,
+    `Expected GET /students/${studentId}/interests to return 200, received ${result.status}: ${JSON.stringify(result.body)}`,
   );
   assert.ok(Array.isArray(result.body), `Expected stored interests to be a list, received ${JSON.stringify(result.body)}`);
   return result.body.map((theme) => theme?.name);
 }
 
-/** Save `names` as the interest student's interests through the real endpoint, as that student. */
-async function stageInterests(names) {
-  const token = await loginAs('interest student');
-  const result = await backendApi(`/students/${INTEREST_STUDENT_ID}/interests`, token, {
+/** Save `names` as a student's interests through the real endpoint, as that student. */
+async function stageInterests(role, names) {
+  const studentId = ROLE_ACTORS[role].id;
+  const result = await themeApi(`/students/${studentId}/interests`, await loginAs(role), {
     method: 'PUT',
     body: JSON.stringify({ theme_ids: await themeIdsForNames(names) }),
   });
@@ -159,7 +135,7 @@ async function stageInterests(names) {
 
   // Staging must not silently under-deliver: read back what the backend stored.
   assert.deepEqual(
-    [...await persistedInterestNames()].sort(),
+    [...await persistedInterestNames(studentId)].sort(),
     parseNames(names).sort(),
     `Expected interest staging to store exactly '${names}'`,
   );
@@ -268,11 +244,11 @@ Given('I call the interest API without a JWT token', function () {
 // --- Staging -----------------------------------------------------------------
 
 Given('the E2E interest student has interests {string}', async function (names) {
-  await stageInterests(names);
+  await stageInterests('interest student', names);
 });
 
 Given('the E2E interest student has no interests', async function () {
-  await stageInterests('');
+  await stageInterests('interest student', '');
 });
 
 // --- Requests ----------------------------------------------------------------
@@ -294,6 +270,14 @@ async function putInterests(world, studentId, themeIds) {
 
 When("I replace the E2E interest student's interests with themes {string}", async function (names) {
   await putInterests(this, INTEREST_STUDENT_ID, await themeIdsForNames(names));
+});
+
+When("I replace the E2E other student's interests with themes {string}", async function (names) {
+  await putInterests(this, OTHER_STUDENT_ID, await themeIdsForNames(names));
+});
+
+When("I replace the E2E interest student's interests with a theme id ending in a backslash", async function () {
+  await putInterests(this, INTEREST_STUDENT_ID, [BACKSLASH_THEME_ID]);
 });
 
 When("I replace the E2E interest student's interests with no themes", async function () {
@@ -355,6 +339,14 @@ Then('the latest interest API error detail should contain {string}', function (e
   );
 });
 
+Then('the latest interest API error detail should list the backslash theme id in full', function () {
+  const detail = interestState(this).payload?.detail;
+  assert.ok(
+    typeof detail === 'string' && detail.includes(BACKSLASH_THEME_ID),
+    `Expected the error detail to list ${JSON.stringify(BACKSLASH_THEME_ID)} verbatim, received ${JSON.stringify(detail)}`,
+  );
+});
+
 Then('the latest interest API response should list themes {string}', function (names) {
   const payload = interestState(this).payload;
   assert.ok(Array.isArray(payload), `Expected the latest interest API response to be a list, received ${JSON.stringify(payload)}`);
@@ -403,20 +395,24 @@ Then('the theme deletion should have succeeded', function () {
 // --- Persisted-state assertions ---------------------------------------------
 
 Then('the persisted interests of the E2E interest student should be exactly {string}', async function (names) {
-  assert.deepEqual([...await persistedInterestNames()].sort(), parseNames(names).sort());
+  assert.deepEqual([...await persistedInterestNames(INTEREST_STUDENT_ID)].sort(), parseNames(names).sort());
+});
+
+Then('the persisted interests of the E2E other student should be exactly {string}', async function (names) {
+  assert.deepEqual([...await persistedInterestNames(OTHER_STUDENT_ID)].sort(), parseNames(names).sort());
 });
 
 Then('the persisted interests of the E2E interest student should be empty', async function () {
-  assert.deepEqual(await persistedInterestNames(), []);
+  assert.deepEqual(await persistedInterestNames(INTEREST_STUDENT_ID), []);
 });
 
 Then('the persisted interests of the E2E interest student should contain {string} exactly once', async function (name) {
-  const storedNames = await persistedInterestNames();
+  const storedNames = await persistedInterestNames(INTEREST_STUDENT_ID);
   const occurrences = storedNames.filter((stored) => stored === name).length;
   assert.equal(occurrences, 1, `Expected '${name}' to be stored exactly once, found ${occurrences} in ${JSON.stringify(storedNames)}`);
 });
 
 Then('the persisted interests of the E2E interest student should not contain {string}', async function (name) {
-  const storedNames = await persistedInterestNames();
+  const storedNames = await persistedInterestNames(INTEREST_STUDENT_ID);
   assert.ok(!storedNames.includes(name), `Expected '${name}' not to be stored, found ${JSON.stringify(storedNames)}`);
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds student theme-interest persistence and authenticated GET/owner-only PUT endpoints, together with atomic replacement, theme-deletion cleanup, and extensive E2E coverage. It also fixes `build_query` substitution so escaped backslashes remain valid TypeQL literals.
- Adds the `hasInterest` relation and corresponding student/theme roles.
- Adds repository and API operations for reading and replacing interests.
- Removes interest relations when deleting a theme.
- Adds schema, authorization, validation, atomicity, and escaping tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| projojo_backend/db/initDatabase.py | Uses a callback replacement in `build_query` to preserve sanitized backslash escaping. |
| projojo_backend/db/schema.tql | Defines the `hasInterest` relation and permits students and themes to play its cardinality-constrained roles. |
| projojo_backend/domain/repositories/theme_repository.py | Adds atomic interest replacement, interest retrieval, validation of referenced entities, and cleanup during theme deletion. |
| projojo_backend/routes/student_router.py | Exposes authenticated interest reads and owner-authorized interest replacement. |
| projojo_backend/tests/test_initDatabase.py | Covers preservation of escaped quotes, interior backslashes, and trailing backslashes during query construction. |
| tests/e2e/features/ts-task-024-student-interest-api.feature | Specifies schema, authorization, replacement, validation, atomicity, and deletion-integrity scenarios. |
| tests/e2e/steps/ts-task-024-student-interest-api.steps.cjs | Implements API and direct-database test steps for the student-interest scenarios. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ts-24 ai review"](https://github.com/han-aim-cmd-wg/projojo/commit/ff3d47702299379bc9c3497d8ee4a9859d4ebc69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57509277)</sub>

<!-- /greptile_comment -->